### PR TITLE
Add option to change locale

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@rollup/plugin-node-resolve": "^9.0.0",
     "@rollup/plugin-typescript": "^6.0.0",
     "@types/node": "^14.14.8",
+    "countries-list": "^2.5.6",
     "obsidian": "https://github.com/obsidianmd/obsidian-api/tarball/master",
     "obsidian-sample-plugin": "https://github.com/obsidianmd/obsidian-api/tarball/master",
     "rollup": "^2.33.3",

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,31 @@
+import { countries, languagesAll } from 'countries-list'
+
+function countryOfLocale(countryCode: string): string|null {
+    // @ts-ignore
+    const country = countries[countryCode.toUpperCase()];
+
+    return country ? country.name : null;
+}
+
+function languageOfLocale(languageCode: string): string|null {
+    // @ts-ignore
+    const language = languagesAll[languageCode];
+
+    return language ? language.name : null;
+}
+
+export function languageName(locale: string): string {
+    const codes = locale.split('-');
+    const languageName = languageOfLocale(codes[0] ?? '');
+    const countryName = countryOfLocale(codes[1] ?? '');
+
+    if (languageName && countryName) {
+        return `${languageName} (${countryName})`;
+    }
+
+    if (languageName) {
+        return languageName;
+    }
+
+    return locale;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { promisify } from "util";
 import { replace_internal_templates } from "./internal_templates";
 import { TemplaterSettings, TemplaterSettingTab } from './settings';
 import { replace_internal_command_templates } from './internal_command_templates';
+import moment from 'moment';
 
 const exec_promise = promisify(exec);
 
@@ -166,6 +167,8 @@ export default class TemplaterPlugin extends Plugin {
 			this.overload_daily_notes();
 		}
 
+		this.change_locale(this.settings.locale);
+
 		// TODO: find a good icon
 		this.addRibbonIcon('three-horizontal-bars', 'Templater', async () => {
 			try {
@@ -220,6 +223,10 @@ export default class TemplaterPlugin extends Plugin {
 
 	async onunload() {
 		await this.saveData(this.settings);
+	}
+
+	change_locale(locale: string) {
+		moment.locale(locale);
 	}
 }
 


### PR DESCRIPTION
Hey @SilentVoid13 

great plugin! One thing I was missing is the ability to change the locale so that the dates are formatted with (in my case) german week and month names.

I added an option to the settings to let the user choose their locale. The dropdown shows all locales available in moment.js. 