### PR TITLE
Adding Internal Templates for NextDay and PrevDay

### DIFF
--- a/data.json
+++ b/data.json
@@ -1,0 +1,1 @@
+{"command_timeout":5,"template_folder":"","templates_pairs":[["",""]],"locale":"en"}

--- a/data.json
+++ b/data.json
@@ -1,1 +1,0 @@
-{"command_timeout":5,"template_folder":"","templates_pairs":[["",""]],"locale":"en"}

--- a/src/internal_templates.ts
+++ b/src/internal_templates.ts
@@ -309,7 +309,7 @@ async function tp_include(app: App, args: {[key: string]: string}): Promise<Stri
     return content;
 }
 
-async function tp_nextday(_app: App, args: {[key: string]: string}): Promise<String> {
+async function tp_nextday(app: App, args: {[key: string]: string}): Promise<String> {
     let nextday;
     let activeLeaf = app.workspace.activeLeaf;
     let title;
@@ -336,7 +336,7 @@ async function tp_nextday(_app: App, args: {[key: string]: string}): Promise<Str
     return nextday;
 }
 
-async function tp_prevday(_app: App, args: {[key: string]: string}): Promise<String> {
+async function tp_prevday(app: App, args: {[key: string]: string}): Promise<String> {
     let prevday;
     let activeLeaf = app.workspace.activeLeaf;
     let title;

--- a/src/internal_templates.ts
+++ b/src/internal_templates.ts
@@ -318,15 +318,20 @@ async function tp_nextday(_app: App, args: {[key: string]: string}): Promise<Str
         throw new Error("app.activeLeaf is null");
     }
     title = activeLeaf.getDisplayText();
-
-    //check for format flags
-    if (existing_argument(args, "f")) {
-        let format = args["f"];
-        nextday = moment(title).add(1,'days').format(format);
+    //check to make sure the title is a vald ISO8601 format
+    if(moment(title, moment.ISO_8601).isValid()){
+        //check for format flags
+        if (existing_argument(args, "f")) {
+            let format = args["f"];
+            nextday = moment(title).add(1,'days').format(format);
+        }
+        else {
+            let m = moment(title).add(1,'days');
+            nextday = m.format(m.creationData().format); //create the next day with the original formatting
+        }
     }
-    else {
-        let m = moment(title).add(1,'days');
-        nextday = m.format(m.creationData().format); //create the next day with the original formatting
+    else{ //non-ISO8601 format, failing over to default format
+        nextday = moment(title).add(1, 'days').format("YYYY-MM-DD");
     }
     return nextday;
 }
@@ -340,15 +345,20 @@ async function tp_prevday(_app: App, args: {[key: string]: string}): Promise<Str
         throw new Error("app.activeLeaf is null");
     }
     title = activeLeaf.getDisplayText();
-
-    //check for format flags
-    if (existing_argument(args, "f")) {
-        let format = args["f"];
-        prevday = moment(title).add(-1,'days').format(format);
+    //check to make sure the title is a vald ISO8601 format
+    if(moment(title, moment.ISO_8601).isValid()){
+        //check for format flags
+        if (existing_argument(args, "f")) {
+            let format = args["f"];
+            prevday = moment(title).add(-1,'days').format(format);
+        }
+        else {
+            let m = moment(title).add(-1,'days');
+            prevday = m.format(m.creationData().format); //create the next day with the original formatting
+        }
     }
-    else {
-        let m = moment(title).add(-1,'days');
-        prevday = m.format(m.creationData().format); //create the next day with the original formatting
+    else{ //non-ISO8601 format, failing over to default format
+        prevday = moment(title).add(-1, 'days').format("YYYY-MM-DD");
     }
     return prevday;
 }

--- a/src/internal_templates.ts
+++ b/src/internal_templates.ts
@@ -333,12 +333,22 @@ async function tp_nextday(_app: App, args: {[key: string]: string}): Promise<Str
 
 async function tp_prevday(_app: App, args: {[key: string]: string}): Promise<String> {
     let prevday;
+    let activeLeaf = app.workspace.activeLeaf;
+    let title;
+    //check for title and store value
+    if (activeLeaf == null) {
+        throw new Error("app.activeLeaf is null");
+    }
+    title = activeLeaf.getDisplayText();
+
+    //check for format flags
     if (existing_argument(args, "f")) {
         let format = args["f"];
-        prevday = moment().add(-1,'days').format(format);
+        prevday = moment(title).add(-1,'days').format(format);
     }
     else {
-        prevday = moment().add(-1,'days').format("YYYY-MM-DD");
+        let m = moment(title).add(-1,'days');
+        prevday = m.format(m.creationData().format); //create the next day with the original formatting
     }
     return prevday;
 }

--- a/src/internal_templates.ts
+++ b/src/internal_templates.ts
@@ -18,6 +18,8 @@ export const internal_templates_map: {[id: string]: Function} = {
     "title_picture": tp_title_picture,
     "creation_date": tp_creation_date,
     "last_modif_date": tp_last_modif_date,
+    "nextday": tp_nextday,
+    "prevday": tp_prevday
 };
 
 export async function replace_internal_templates(app: App, content: string) {
@@ -305,4 +307,38 @@ async function tp_include(app: App, args: {[key: string]: string}): Promise<Stri
     let content = await app.vault.read(file);
 
     return content;
+}
+
+async function tp_nextday(_app: App, args: {[key: string]: string}): Promise<String> {
+    let nextday;
+    let activeLeaf = app.workspace.activeLeaf;
+    let title;
+    //check for title and store value
+    if (activeLeaf == null) {
+        throw new Error("app.activeLeaf is null");
+    }
+    title = activeLeaf.getDisplayText();
+
+    //check for format flags
+    if (existing_argument(args, "f")) {
+        let format = args["f"];
+        nextday = moment(title).add(1,'days').format(format);
+    }
+    else {
+        let m = moment(title).add(1,'days');
+        nextday = m.format(m.creationData().format); //create the next day with the original formatting
+    }
+    return nextday;
+}
+
+async function tp_prevday(_app: App, args: {[key: string]: string}): Promise<String> {
+    let prevday;
+    if (existing_argument(args, "f")) {
+        let format = args["f"];
+        prevday = moment().add(-1,'days').format(format);
+    }
+    else {
+        prevday = moment().add(-1,'days').format("YYYY-MM-DD");
+    }
+    return prevday;
 }


### PR DESCRIPTION
(This is my first ever pull request for a public repo so if I did something wrong feel free to let me know). 

I use your Templater a lot, but I also like to create notes in the future for certain reasons. I use a breadcrumb linking syntax at the top of my notes for yesterday and tomorrow, however, your `tp_yesterday` and `tp_tomorrow` do not work unless you create the note for 'today' 

This functionality I am requesting be added will allow you to create a 'previous' and 'next' day links. 
The syntax is `{{tp_nextday}}` and `{{tp_prevday}}`.
It is based on the title of the note that is being created to get the 'base date' to generate the next and previous days. Because of this I added a check in the code to verify that the title is a valid ISO8601 date. 

I then use moments built in functions to increase or decrease the days. I use the `moment.createData()` function to keep the original formatting of the title (unless it fails the ISO check). 

Here is a vid cap of some tests with it:

https://user-images.githubusercontent.com/7501413/104061999-3a152600-51bf-11eb-8b7a-323811e8c579.mov

