### PR TITLE
Added "Replace" in active file command

### DIFF
--- a/src/fuzzy_suggester.ts
+++ b/src/fuzzy_suggester.ts
@@ -73,6 +73,17 @@ export class TemplaterFuzzySuggestModal extends FuzzySuggestModal<TFile> {
         }
     }
 
+    replace(): void {
+        try {
+            var activeLeaf = this.app.workspace.activeLeaf;
+            var file = activeLeaf.view.file;
+            this.replace_templates_and_overwrite_in_file(file);
+        }
+        catch(error) {
+            new Notice(error);
+        }
+    }
+
     async replace_templates_and_append(template_file: TFile) {
         let active_view = this.app.workspace.getActiveViewOfType(MarkdownView);
         if (active_view == null) {

--- a/src/fuzzy_suggester.ts
+++ b/src/fuzzy_suggester.ts
@@ -75,9 +75,11 @@ export class TemplaterFuzzySuggestModal extends FuzzySuggestModal<TFile> {
 
     replace(): void {
         try {
-            var activeLeaf = this.app.workspace.activeLeaf;
-            var file = activeLeaf.view.file;
-            this.replace_templates_and_overwrite_in_file(file);
+            let active_view = this.app.workspace.getActiveViewOfType(MarkdownView);
+            if (active_view == null) {
+                throw new Error("Active view is null");
+            }
+            this.replace_templates_and_overwrite_in_file(active_view.file);
         }
         catch(error) {
             new Notice(error);

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,6 +37,20 @@ export default class TemplaterPlugin extends Plugin {
 			},
 		});
 
+		this.addCommand({
+            id: "replace-in-file-templater",
+            name: "Replace Templates in Open File",
+            hotkeys: [
+                {
+                    modifiers: ["Alt"],
+                    key: 'r',
+                },
+            ],
+            callback: () => {
+                this.fuzzy_suggester.replace();
+            },
+        });
+
 		this.app.workspace.on("layout-ready", () => {
 			// TODO: Find a way to not trigger this on files copy
 			this.app.vault.on("create", async (file: TAbstractFile) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,7 +39,7 @@ export default class TemplaterPlugin extends Plugin {
 
 		this.addCommand({
             id: "replace-in-file-templater",
-            name: "Replace Templates in Open File",
+            name: "Replace templates in the active file",
             hotkeys: [
                 {
                     modifiers: ["Alt"],


### PR DESCRIPTION
The added command allows you to replace any templates in your active file.

This is useful if the file has already been created and you just want to add something to it using the custom templates.

add a Templater template (such as ```{{tp_now}}``` anywhere in an open document, and run the Replace in Open File command, to expand that template.