### PR TITLE
feat: Allow users to provide a default template for empty new files

### DIFF
--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -102,8 +102,12 @@ export class TemplaterSettingTab extends PluginSettingTab {
 						this.plugin.settings.trigger_on_file_creation = trigger_on_file_creation;
 						this.plugin.saveSettings();
 						this.plugin.update_trigger_file_on_creation();
+						// Force refresh
+						this.display();
 					});
 			});
+
+		if (this.plugin.settings.trigger_on_file_creation) {
 			desc = document.createDocumentFragment();
 			desc.append(
 				"Templater will automatically apply this template file to new empty files as they are created.",
@@ -125,6 +129,7 @@ export class TemplaterSettingTab extends PluginSettingTab {
 							this.plugin.update_trigger_file_on_creation();
 					});
 			});
+		}
 
 		desc = document.createDocumentFragment();
 		desc.append(

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -11,7 +11,7 @@ export const DEFAULT_SETTINGS: TemplaterSettings = {
 	enable_system_commands: false,
 	shell_path: "",
 	script_folder: undefined,
-	default_file_template: undefined,
+	empty_file_template: undefined,
 };
 
 export interface TemplaterSettings {
@@ -22,7 +22,7 @@ export interface TemplaterSettings {
 	enable_system_commands: boolean;
 	shell_path: string,
 	script_folder: string,
-	default_file_template: string,
+	empty_file_template: string,
 };
 
 export class TemplaterSettingTab extends PluginSettingTab {
@@ -110,36 +110,23 @@ export class TemplaterSettingTab extends PluginSettingTab {
 		if (this.plugin.settings.trigger_on_file_creation) {
 			desc = document.createDocumentFragment();
 			desc.append(
-				"Templater will automatically apply this template file to new empty files as they are created.",
+				"Templater will automatically apply this template to new empty files when they are created.",
 				desc.createEl("br"),
-				"Requires 'Trigger Templater on new file creation' to be enabled, and file to be accessible from the vault.",
-				desc.createEl("br"),
-				"Templater will only apply the template to empty files, in order to maintain compatibility with other plugins like the Daily note core plugin, Calendar plugin, Review plugin, Note refactor plugin, ...",
+				"The .md extension for the file shouldn't be specified."
 			);
 			
 			new Setting(containerEl)
-				.setName("Default template file")
+				.setName("Empty file template")
 				.setDesc(desc)
 				.addText(text => {
-					text.setPlaceholder("folder 1/default_file")
-						.setValue(this.plugin.settings.default_file_template)
-						.onChange((new_default_file_template) => {
-							this.plugin.settings.default_file_template = new_default_file_template;
+					text.setPlaceholder("folder 1/template_file")
+						.setValue(this.plugin.settings.empty_file_template)
+						.onChange((empty_file_template) => {
+							this.plugin.settings.empty_file_template = empty_file_template;
 							this.plugin.saveSettings();
-							this.plugin.update_trigger_file_on_creation();
-					});
-			});
+						});
+				});
 		}
-
-		desc = document.createDocumentFragment();
-		desc.append(
-			"Allows you to create user functions linked to system commands.",
-			desc.createEl("br"),
-			desc.createEl("b", {
-				text: "Warning: "
-			}),
-			"It can be dangerous to execute arbitrary system commands from untrusted sources. Only run system commands that you understand, from trusted sources.",
-		);
 
 		desc = document.createDocumentFragment();
 		desc.append(
@@ -166,6 +153,16 @@ export class TemplaterSettingTab extends PluginSettingTab {
 						this.plugin.saveSettings();
 					})
 			});
+
+		desc = document.createDocumentFragment();
+		desc.append(
+			"Allows you to create user functions linked to system commands.",
+			desc.createEl("br"),
+			desc.createEl("b", {
+				text: "Warning: "
+			}),
+			"It can be dangerous to execute arbitrary system commands from untrusted sources. Only run system commands that you understand, from trusted sources.",
+		);
 
 		new Setting(containerEl)
 			.setName("Enable System Commands")

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -11,6 +11,7 @@ export const DEFAULT_SETTINGS: TemplaterSettings = {
 	enable_system_commands: false,
 	shell_path: "",
 	script_folder: undefined,
+	default_file_template: undefined,
 };
 
 export interface TemplaterSettings {
@@ -21,6 +22,7 @@ export interface TemplaterSettings {
 	enable_system_commands: boolean;
 	shell_path: string,
 	script_folder: string,
+	default_file_template: string,
 };
 
 export class TemplaterSettingTab extends PluginSettingTab {

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -104,6 +104,27 @@ export class TemplaterSettingTab extends PluginSettingTab {
 						this.plugin.update_trigger_file_on_creation();
 					});
 			});
+			desc = document.createDocumentFragment();
+			desc.append(
+				"Templater will automatically apply this template file to new empty files as they are created.",
+				desc.createEl("br"),
+				"Requires 'Trigger Templater on new file creation' to be enabled, and file to be accessible from the vault.",
+				desc.createEl("br"),
+				"Templater will only apply the template to empty files, in order to maintain compatibility with other plugins like the Daily note core plugin, Calendar plugin, Review plugin, Note refactor plugin, ...",
+			);
+			
+			new Setting(containerEl)
+				.setName("Default template file")
+				.setDesc(desc)
+				.addText(text => {
+					text.setPlaceholder("folder 1/default_file")
+						.setValue(this.plugin.settings.default_file_template)
+						.onChange((new_default_file_template) => {
+							this.plugin.settings.default_file_template = new_default_file_template;
+							this.plugin.saveSettings();
+							this.plugin.update_trigger_file_on_creation();
+					});
+			});
 
 		desc = document.createDocumentFragment();
 		desc.append(

--- a/src/Templater.ts
+++ b/src/Templater.ts
@@ -32,19 +32,6 @@ export class Templater {
         await this.parser.init();
     }
 
-    async errorWrapper(fn: Function): Promise<any> {
-        try {
-            return await fn();
-        } catch(e) {
-            if (!(e instanceof TemplaterError)) {
-                this.plugin.log_error(new TemplaterError(`Template parsing error, aborting.`, e.message));
-            } else {
-                this.plugin.log_error(e);
-            }
-            return null;
-        }
-    }
-
     create_running_config(template_file: TFile, target_file: TFile, run_mode: RunMode) {
         return {
             template_file: template_file,
@@ -70,7 +57,7 @@ export class Templater {
 
         const running_config = this.create_running_config(template_file, created_note, RunMode.CreateNewFromTemplate);
 
-        const output_content = await this.errorWrapper(async () => this.read_and_parse_template(running_config));
+        const output_content = await this.plugin.errorWrapper(async () => this.read_and_parse_template(running_config));
         if (output_content == null) {
             await this.app.vault.delete(created_note);
             return;
@@ -94,7 +81,7 @@ export class Templater {
             return;
         }
         const running_config = this.create_running_config(template_file, active_view.file, RunMode.AppendActiveFile);
-        const output_content = await this.errorWrapper(async () => this.read_and_parse_template(running_config));
+        const output_content = await this.plugin.errorWrapper(async () => this.read_and_parse_template(running_config));
         if (output_content == null) {
             return;
         }
@@ -117,7 +104,7 @@ export class Templater {
 
     async overwrite_file_templates(file: TFile, active_file: boolean = false): Promise<void> {
         const running_config = this.create_running_config(file, file, active_file ? RunMode.OverwriteActiveFile : RunMode.OverwriteFile);
-        const output_content = await this.errorWrapper(async () => this.read_and_parse_template(running_config));
+        const output_content = await this.plugin.errorWrapper(async () => this.read_and_parse_template(running_config));
         if (output_content == null) {
             return;
         }
@@ -143,7 +130,7 @@ export class Templater {
             while (match != null) {
                 // Not the most efficient way to exclude the '+' from the command but I couldn't find something better
                 const complete_command = match[1] + match[2];
-                const command_output: string = await this.errorWrapper(async () => {
+                const command_output: string = await this.plugin.errorWrapper(async () => {
                     return await this.parser.parseTemplates(complete_command);
                 });
                 if (command_output == null) {

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -9,14 +9,28 @@ export function delay(ms: number): Promise<void> {
 
 export function escapeRegExp(str: string): string {
     return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+} 
+
+export function resolveTFile(app: App, file_str: string): TFile {
+    file_str = normalizePath(file_str);
+
+    const file = app.vault.getAbstractFileByPath(file_str);
+    if (!file) {
+        throw new TemplaterError(`File "${file_str}" doesn't exist`);
+    }
+    if (!(file instanceof TFile)) {
+        throw new TemplaterError(`${file_str} is a folder, not a file`);
+    }
+
+    return file;
 }
 
 export function getTFilesFromFolder(app: App, folder_str: string): Array<TFile> {
     folder_str = normalizePath(folder_str);
 
-    let folder = app.vault.getAbstractFileByPath(folder_str);
+    const folder = app.vault.getAbstractFileByPath(folder_str);
     if (!folder) {
-        throw new TemplaterError(`${folder_str} folder doesn't exist`);
+        throw new TemplaterError(`Folder "${folder_str}" doesn't exist`);
     }
     if (!(folder instanceof TFolder)) {
         throw new TemplaterError(`${folder_str} is a file, not a folder`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -125,6 +125,12 @@ export default class TemplaterPlugin extends Plugin {
 				if (!(file instanceof TFile) || file.extension !== "md") {
 					return;
 				}
+				// Check that file is empty in order to to avoid clobbering file content set by other plugins, 
+				// such as Calendar, Daily Notes, etc.
+				if (file.stat.size == 0 && this.settings.default_file_template) {
+					const content = `<% tp.file.include("[[${this.settings.default_file_template}]]") %>`;
+					await this.app.vault.modify(file, content);
+				}
 				this.templater.overwrite_file_templates(file);
 			});
 			this.registerEvent(

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import { addIcon, EventRef, Menu, MenuItem, Notice, Plugin, TAbstractFile, TFile
 import { DEFAULT_SETTINGS, TemplaterSettings, TemplaterSettingTab } from 'Settings';
 import { TemplaterFuzzySuggestModal } from 'TemplaterFuzzySuggest';
 import { ICON_DATA } from 'Constants';
-import { delay } from 'Utils';
+import { delay, resolveTFile } from 'Utils';
 import { Templater } from 'Templater';
 import { TemplaterError } from 'Error';
 
@@ -118,17 +118,23 @@ export default class TemplaterPlugin extends Plugin {
 	update_trigger_file_on_creation(): void {
 		if (this.settings.trigger_on_file_creation) {
 			this.trigger_on_file_creation_event = this.app.vault.on("create", async (file: TAbstractFile) => {
+				if (!(file instanceof TFile) || file.extension !== "md") {
+					return;
+				}
+
 				// TODO: find a better way to do this
 				// Currently, I have to wait for the daily note plugin to add the file content before replacing
 				// Not a problem with Calendar however since it creates the file with the existing content
 				await delay(300);
-				if (!(file instanceof TFile) || file.extension !== "md") {
-					return;
-				}
-				// Check that file is empty in order to to avoid clobbering file content set by other plugins, 
-				// such as Calendar, Daily Notes, etc.
-				if (file.stat.size == 0 && this.settings.default_file_template) {
-					const content = `<% tp.file.include("[[${this.settings.default_file_template}]]") %>`;
+
+				if (file.stat.size == 0 && this.settings.empty_file_template) {
+					const template_file = await this.errorWrapper(async (): Promise<TFile> => {
+						return resolveTFile(this.app, this.settings.empty_file_template + ".md");
+					});
+					if (!template_file) {
+						return;
+					}
+					const content = await this.app.vault.read(template_file);
 					await this.app.vault.modify(file, content);
 				}
 				this.templater.overwrite_file_templates(file);
@@ -142,6 +148,19 @@ export default class TemplaterPlugin extends Plugin {
 				this.app.vault.offref(this.trigger_on_file_creation_event);
 				this.trigger_on_file_creation_event = undefined;
 			}
+		}
+	}
+
+	async errorWrapper(fn: Function): Promise<any> {
+		try {
+			return await fn();
+		} catch(e) {
+			if (!(e instanceof TemplaterError)) {
+				this.log_error(new TemplaterError(`Template parsing error, aborting.`, e.message));
+			} else {
+				this.log_error(e);
+			}
+			return null;
 		}
 	}
 


### PR DESCRIPTION
Addresses https://github.com/SilentVoid13/Templater/issues/200

- requires `trigger_on_file_creation` to be enabled
- only runs on files with no content



<details>
  <summary>For an example of what a default template might look like:</summary>

```js
<%*
// This logic is actually defined as a Script User Function
// so I can just do:
// const defaultTemplate = tp.user.getDefaultTemplate(tp);
const fallback_template = "[[assets/templates/fallback]]";
const config = [
  { 
    regex: /^\d{4}-\d{2}-\d{2}$/,
    template: "[[assets/templates/daily_note]]"
  },
  { 
    regex: /^\d{4}-\d{2}-W\d{2}$/,
    template: "[[assets/templates/weekly_note]]"
  },
  { 
    regex: /^\d{4}-\d{2}$/,
    template: "[[assets/templates/monthly_note]]"
  },
  {
    regex: /^\d{4}-Q\d{1}$/,
    template: "[[assets/templates/quarterly_note]]"
  },
  {
    regex: /^\d{4}$/,
    template: "[[assets/templates/annual_note]]"
  },
];

const title = tp.file.title;

const matching_default = config
  .find(item => item.regex.test(title));

if (matching_default) {
  const default_template = matching_default.template;
} else {
  const default_template = fallback_template;
}
-%>
<% tp.file.include(default_template) -%>
```
</details>
