### PR TITLE
Do not replace dynamic templates on initial expansion

### DIFF
--- a/src/TemplateParser.ts
+++ b/src/TemplateParser.ts
@@ -17,6 +17,7 @@ export class TemplateParser implements TParser {
     public internalTemplateParser: InternalTemplateParser;
 	public userTemplateParser: UserTemplateParser;
     public current_context: {};
+    private dynamicPlaceholder = "TP_DYNAMIC_PLACEHOLDER";
     
     constructor(private app: App, private plugin: TemplaterPlugin) {
         this.internalTemplateParser = new InternalTemplateParser(this.app, this.plugin);
@@ -71,6 +72,7 @@ export class TemplateParser implements TParser {
             context = this.current_context;
         }
 
+        content = content.replace(/<%\+/g, this.dynamicPlaceholder);
         content = await Eta.renderAsync(content, context, {
             varName: "tp",
             parse: {
@@ -81,6 +83,7 @@ export class TemplateParser implements TParser {
             autoTrim: false,
             globalAwait: true,
         }) as string;
+        content = content.replace(new RegExp(this.dynamicPlaceholder, "g"), "<%+");
 
         return content;
     }


### PR DESCRIPTION
This is a fix for #188.

## Cause
The bug is caused by `Eta` trying to render both static and dynamic templates when inserting a template, because it's matching the dynamic template. I think it's reading the dynamic template as `undefined + some_val`, which is why `NaN` is inserted.

## Fix
I'm fixing this by simply swapping out the opening interpolation tag with a temporary string (one unlikely to be used within the actual template), and then swapping back to the the correct tag after rendering the template.

Note: I haven't been able to run the tests (see #212), but happy to do so with a little instruction.  