### PR TITLE
Update doc references for internal config module

### DIFF
--- a/docs/docs/internal-variables-functions/internal-modules/config-module.md
+++ b/docs/docs/internal-variables-functions/internal-modules/config-module.md
@@ -2,7 +2,7 @@
 title: Config Module
 ---
 
-This module exposes Templater's [running configuration](https://github.com/SilentVoid13/Templater/blob/master/src/Templater.ts#L15). 
+This module exposes Templater's [running configuration](https://github.com/SilentVoid13/Templater/blob/master/src/Templater.ts#L16). 
 
 This is mostly useful when writing scripts requiring some context informations.
 
@@ -10,4 +10,4 @@ This is mostly useful when writing scripts requiring some context informations.
 | ---------------------------- | ------------------------------------------------------------ |
 | `tp.config.template_file`    | The `TFile` object representing the template file.           |
 | `tp.config.target_file`      | The `TFile` object representing the target file where the template will be inserted |
-| `tp.config.run_mode`         | The `RunMode` [enumeration](https://github.com/SilentVoid13/Templater/blob/master/src/Templater.ts#L15), representing the way Templater was launched (Create new from template, Append to active file, ...) |
+| `tp.config.run_mode`         | The `RunMode` [enumeration](https://github.com/SilentVoid13/Templater/blob/master/src/Templater.ts#L8), representing the way Templater was launched (Create new from template, Append to active file, ...) |


### PR DESCRIPTION
This commit updates the doc links to point to the correct lines before the 1.8.0 release as the contents of the file they were referencing has changed.