### PR TITLE
Handle JS user templates on mobile

### DIFF
--- a/src/UserTemplates/UserTemplateParser.ts
+++ b/src/UserTemplates/UserTemplateParser.ts
@@ -45,7 +45,7 @@ export class UserTemplateParser implements TParser {
     async load_user_script_function(config: RunningConfig, file: TFile): Promise<void> {
         if (Platform.isMobileApp) {
             const content = await this.app.vault.read(file)
-            const newContent = content.replace(/module\.exports\(.+\)/, "")
+            const newContent = content.replace(/module\.exports = .+/, "")
             const func = Function(`return ${newContent}`)()
             this.user_script_functions.set(`${file.basename}`, func);
         } else {


### PR DESCRIPTION
Added handling for importing user templates when on Obsidian mobile. Instead of using the `adapter` I am reading the JS file with `app.vault.read` and then converting the returned string to a function using the `Function` constructor. because this doesn't user `module.exports` I'm stripping it from the string using regex. Changes are on lines 46-51. The other changes are formatting.