### PR TITLE
Feat: Folder Templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
-# Intellij
+# Editors
+
+## Intellij
 *.iml
 .idea
+
+## VSCode
+.vscode/
 
 # npm
 node_modules
@@ -14,7 +19,10 @@ main.test.js
 test/
 tests_jest/
 
-RESOURCES.md
+# Obsidian
 data.json
 .hotreload
 resources/
+
+# Other
+RESOURCES.md

--- a/docs/docs/settings.md
+++ b/docs/docs/settings.md
@@ -10,13 +10,17 @@ You can set [Templater](https://github.com/SilentVoid13/Templater) to be trigger
 
 This makes Templater compatible with other plugins like the Daily note core plugin, Calendar plugin, Review plugin, Note refactor plugin, ...
 
-If this setting is enabled, you can specify an "Empty File Template", which is a template that will automatically be added to newly created file.
+## Folder Templates
+
+You can specify a template that will automatically be used on a selected folder and children using the `Folder Templates` functionality.
 
 :::caution 
 
 This can be dangerous if you create new files with unknown / unsafe content on creation. Make sure that every new file's content is safe on creation.
 
 :::
+
+## System Commands
 
 You can enable system commands. This allows you to create [user functions](./user-functions/overview.md) linked to system commands.
 

--- a/docs/docs/settings.md
+++ b/docs/docs/settings.md
@@ -10,15 +10,15 @@ You can set [Templater](https://github.com/SilentVoid13/Templater) to be trigger
 
 This makes Templater compatible with other plugins like the Daily note core plugin, Calendar plugin, Review plugin, Note refactor plugin, ...
 
-## Folder Templates
-
-You can specify a template that will automatically be used on a selected folder and children using the `Folder Templates` functionality.
-
 :::caution 
 
 This can be dangerous if you create new files with unknown / unsafe content on creation. Make sure that every new file's content is safe on creation.
 
 :::
+
+## Folder Templates
+
+You can specify a template that will automatically be used on a selected folder and children using the `Folder Templates` functionality.
 
 ## System Commands
 

--- a/src/FolderTemplate.ts
+++ b/src/FolderTemplate.ts
@@ -1,5 +1,0 @@
-
-export interface FolderTemplate {
-    folder: string;
-    template: string;
-}

--- a/src/FolderTemplate.ts
+++ b/src/FolderTemplate.ts
@@ -1,0 +1,5 @@
+
+export interface FolderTemplate {
+    folder: string;
+    template: string;
+}

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -5,6 +5,7 @@ import { FileSuggest, FileSuggestMode } from 'suggesters/FileSuggester';
 import TemplaterPlugin from './main';
 import { arraymove, get_tfiles_from_folder, unzip } from 'Utils';
 import { log_error } from 'Log';
+import { FolderTemplate } from "FolderTemplate";
 
 export const DEFAULT_SETTINGS: Settings = {
 	command_timeout: 5,
@@ -15,7 +16,7 @@ export const DEFAULT_SETTINGS: Settings = {
 	shell_path: "",
 	user_scripts_folder: "",
 	use_new_file_templates: true,
-	new_file_templates: [["", ""]],
+	new_file_templates: [{folder: "", template: ""}],
 	syntax_highlighting: true,
     enabled_templates_hotkeys: [""],
     startup_templates: [""],
@@ -30,7 +31,7 @@ export interface Settings {
 	shell_path: string;
 	user_scripts_folder: string;
 	use_new_file_templates: boolean;
-	new_file_templates: Array<[string, string]>;
+	new_file_templates: Array<FolderTemplate>;
 	syntax_highlighting: boolean;
     enabled_templates_hotkeys: Array<string>;
     startup_templates: Array<string>;
@@ -187,28 +188,28 @@ export class TemplaterSettingTab extends PluginSettingTab {
 					.setButtonText("+")
 					.setCta()
 					.onClick(() => {
-						this.plugin.settings.new_file_templates.push(["", ""]);
+						this.plugin.settings.new_file_templates.push({folder: "", template: ""});
                         this.display();
 					})
 				
 				return b;
 			});
 
-		this.plugin.settings.new_file_templates.forEach((pair, index) => {
+		this.plugin.settings.new_file_templates.forEach((folder_template, index) => {
 			const s = new Setting(this.containerEl)
 				.setName("Folder Template")
 				.addSearch(cb => {
 					new FolderSuggest(this.app, cb.inputEl);
 					cb
 						.setPlaceholder("Folder")
-						.setValue(pair[0])
+						.setValue(folder_template.folder)
 						.onChange((new_folder) => {
-							if (new_folder !== "" && unzip(this.plugin.settings.new_file_templates)[0].contains(new_folder)) {
+							if (new_folder !== "" && this.plugin.settings.new_file_templates.some(e => e.folder == new_folder)) {
 								log_error(new TemplaterError("This folder already has a template associated with it"));
                                 return;
 							}
 							
-							this.plugin.settings.new_file_templates[index][0] = new_folder;
+							this.plugin.settings.new_file_templates[index].folder = new_folder;
 							this.plugin.save_settings();
 						})
 				})
@@ -216,9 +217,9 @@ export class TemplaterSettingTab extends PluginSettingTab {
 					new FileSuggest(this.app, cb.inputEl, this.plugin, FileSuggestMode.TemplateFiles);
 					cb
 						.setPlaceholder("Template")
-						.setValue(pair[1])
+						.setValue(folder_template.template)
 						.onChange((new_template) => {
-							this.plugin.settings.new_file_templates[index][1] = new_template;
+							this.plugin.settings.new_file_templates[index].template = new_template;
 							this.plugin.save_settings();
 						})
 				})

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -159,7 +159,7 @@ export class TemplaterSettingTab extends PluginSettingTab {
     }
 
     add_templates_hotkeys_setting() {
-        this.containerEl.createEl("h2", { text: "Templates Hotkeys"});
+        this.containerEl.createEl("h2", { text: "Template Hotkeys"});
 
         this.plugin.settings.enabled_templates_hotkeys.forEach((template, index) => {
             const s = new Setting(this.containerEl)

--- a/src/Templater.ts
+++ b/src/Templater.ts
@@ -7,6 +7,7 @@ import { errorWrapper, errorWrapperSync, TemplaterError } from "Error";
 import { Editor } from 'editor/Editor';
 import { Parser } from 'parser/Parser';
 import { log_error } from 'Log';
+import { FolderTemplate } from "FolderTemplate";
 
 export enum RunMode {
     CreateNewFromTemplate,
@@ -221,13 +222,13 @@ export class Templater {
         }
 	}
 
-    get_new_file_template_for_folder(folder: TFolder): undefined | string {
-        let match = this.plugin.settings.new_file_templates.find(e => e[0] == folder.path);
+    get_new_file_template_for_folder(folder: TFolder): undefined | FolderTemplate {
+        let match = this.plugin.settings.new_file_templates.find(e => e.folder == folder.path);
 
         if (folder.isRoot()) {
-            return match ? match[1] : undefined;
+            return match.template;
         } else {
-            return match ? match[1] : undefined || this.get_new_file_template_for_folder(folder.parent);
+            return match.template || this.get_new_file_template_for_folder(folder.parent);
         }
     }
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -56,16 +56,6 @@ export function get_tfiles_from_folder(app: App, folder_str: string): Array<TFil
     return files;
 }
 
-export function unzip(arr: any[], size: number = 0) {
-    // Python-style unzip
-    return arr.reduce(
-        (acc, val) => (val.forEach((v: any, i: number) => acc[i].push(v)), acc),
-        Array.from({
-          length: size || Math.max(...arr.map((x) => x.length)),
-        }).map(() => [])
-      );
-};
-
 export function arraymove(arr: any[], fromIndex: number, toIndex: number) {
     var element = arr[fromIndex];
     arr.splice(fromIndex, 1);

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -55,3 +55,19 @@ export function get_tfiles_from_folder(app: App, folder_str: string): Array<TFil
 
     return files;
 }
+
+export function unzip(arr: any[], size: number = 0) {
+    // Python-style unzip
+    return arr.reduce(
+        (acc, val) => (val.forEach((v: any, i: number) => acc[i].push(v)), acc),
+        Array.from({
+          length: size || Math.max(...arr.map((x) => x.length)),
+        }).map(() => [])
+      );
+};
+
+export function arraymove(arr: any[], fromIndex: number, toIndex: number) {
+    var element = arr[fromIndex];
+    arr.splice(fromIndex, 1);
+    arr.splice(toIndex, 0, element);
+};


### PR DESCRIPTION
Implements folder-based templates similar to the functionality provided
by Vinzent03's `Hotkeys for Templates` plugin.

Since Templater also implements hotkeys directly, I think most people
will now be able to get all the functionality from Hotkeys for Templates
using just Templater.

Since this functionality supercedes the empty file template functionality,
that has been removed.

Fixes: #326