### PR TITLE
Add a better tp.file.create_new example

### DIFF
--- a/docs/docs/internal-variables-functions/internal-modules/file-module.md
+++ b/docs/docs/internal-variables-functions/internal-modules/file-module.md
@@ -40,6 +40,8 @@ File creation date: <% tp.file.creation_date() %>
 File creation date with format: <% tp.file.creation_date("dddd Do MMMM YYYY HH:mm") %>
 
 File creation: [[<% (await tp.file.create_new("MyFileContent", "MyFilename")).basename %>]]
+File creation with a template, a prepended name and automatically opened: 
+<% (tp.file.create_new(tp.file.find_tfile("Comments (Template)"), "Comments: " + tp.file.title, true)) %>
 
 File cursor: <% tp.file.cursor(1) %>
 


### PR DESCRIPTION
It is really not obvious how to generate a new file using a template, especially after an easy `include("[[Template1]]")` example.