### PR TITLE
fix: mobile support for tp.file.path() when relative is true

### DIFF
--- a/src/core/functions/internal_functions/file/InternalModuleFile.ts
+++ b/src/core/functions/internal_functions/file/InternalModuleFile.ts
@@ -256,7 +256,9 @@ export class InternalModuleFile extends InternalModule {
 
     generate_path(): (relative: boolean) => string {
         return (relative = false) => {
-            // TODO: Add mobile support
+            if (relative) {
+                return this.config.target_file.path;
+            }
             if (Platform.isMobileApp) {
                 return UNSUPPORTED_MOBILE_TEMPLATE;
             }
@@ -266,12 +268,7 @@ export class InternalModuleFile extends InternalModule {
                 );
             }
             const vault_path = this.app.vault.adapter.getBasePath();
-
-            if (relative) {
-                return this.config.target_file.path;
-            } else {
-                return `${vault_path}/${this.config.target_file.path}`;
-            }
+            return `${vault_path}/${this.config.target_file.path}`;
         };
     }
 


### PR DESCRIPTION
This was previously unsupported because getting the path to a vault is hard on mobile, as vault.adapter isn't a FileSystemAdapter. However, the vault path isn't required for when relative is set to true.

(Half) Fixes #536

This is just a suggested fix, only supporting 50% of a function on mobile is a little annoying but I made this change last week and it serves me fine. At the very least, other users can make this change if they need. 