### PR TITLE
fix: Activate cursor jump before renaming file

### DIFF
--- a/src/core/Templater.ts
+++ b/src/core/Templater.ts
@@ -167,10 +167,17 @@ export class Templater {
                 return;
             }
             await active_leaf.openFile(created_note, {
-                state: { mode: "source" },
-                eState: { rename: "all" },
+              state: { mode: "source" },
             });
-            await this.plugin.editor_handler.jump_to_next_cursor_location(created_note, true);
+
+            await this.plugin.editor_handler.jump_to_next_cursor_location(
+              created_note,
+              true
+            );
+
+            active_leaf.setEphemeralState({
+              rename: "all",
+            });
         }
 
         return created_note;

--- a/src/editor/Editor.ts
+++ b/src/editor/Editor.ts
@@ -38,7 +38,7 @@ export class Editor {
         if (file && this.app.workspace.getActiveFile() !== file) {
             return;
         }
-        this.cursor_jumper.jump_to_next_cursor_location();
+        await this.cursor_jumper.jump_to_next_cursor_location();
     }
 
     async registerCodeMirrorMode(): Promise<void> {


### PR DESCRIPTION
fixes #564

This fixes a bug where the focus is stolen away from the `rename` input to place it in the document.

Instead, we set the cursor position _first_. Then we trigger the rename. After pressing <kdb>Enter</kbd> from the rename box, the cursor will return to the initial cursor_jump destination as expected.