### PR TITLE
feat: trigger events on template overwrite, new file creation

### DIFF
--- a/src/core/Templater.ts
+++ b/src/core/Templater.ts
@@ -241,6 +241,10 @@ export class Templater {
             return;
         }
         await this.app.vault.modify(file, output_content);
+        this.app.workspace.trigger("templater:new-note-from-template", {
+          file,
+          content: output_content,
+        });
         await this.plugin.editor_handler.jump_to_next_cursor_location(file, true);
     }
 
@@ -276,6 +280,10 @@ export class Templater {
             return;
         }
         await this.app.vault.modify(file, output_content);
+        this.app.workspace.trigger("templater:overwrite-file", {
+          file,
+          content: output_content,
+        });
         await this.plugin.editor_handler.jump_to_next_cursor_location(file, true);
     }
 

--- a/src/obsidian.d.ts
+++ b/src/obsidian.d.ts
@@ -1,0 +1,49 @@
+import "obsidian";
+
+declare module "obsidian" {
+  interface Editor {
+    cm: CodeMirror.Editor;
+  }
+
+  interface FileManager {
+    createNewMarkdownFile: (folder: string, filename: string) => Promise<void>;
+  }
+
+  interface VaultSettings {
+    foldHeading: boolean;
+    foldIndent: boolean;
+    legacyEditor: boolean;
+    newFileLocation: string;
+    readableLineLength: boolean;
+    rightToLeft: boolean;
+    showFrontmatter: boolean;
+    tabSize: number;
+  }
+
+  interface Vault {
+    config: Record<string, any>;
+    getConfig<T extends keyof VaultSettings>(setting: T): VaultSettings[T];
+  }
+
+  export interface PluginInstance {
+    id: string;
+  }
+  export interface ViewRegistry {
+    viewByType: Record<string, (leaf: WorkspaceLeaf) => unknown>;
+    isExtensionRegistered(extension: string): boolean;
+  }
+
+  export interface App {
+    internalPlugins: InternalPlugins;
+    viewRegistry: ViewRegistry;
+  }
+  export interface InstalledPlugin {
+    enabled: boolean;
+    instance: PluginInstance;
+  }
+
+  export interface InternalPlugins {
+    plugins: Record<string, InstalledPlugin>;
+    getPluginById(id: string): InstalledPlugin;
+  }
+}


### PR DESCRIPTION
Other plugins can listen for the workspace events `templater:overwrite-file` and `templater:new-note-from-template` to hook into templater and provide additional functionality