### PR TITLE
Allow User Scripts on Mobile

### DIFF
--- a/src/core/functions/user_functions/UserFunctions.ts
+++ b/src/core/functions/user_functions/UserFunctions.ts
@@ -1,4 +1,4 @@
-import { App, Platform } from "obsidian";
+import { App } from "obsidian";
 
 import TemplaterPlugin from "main";
 import { RunningConfig } from "core/Templater";
@@ -26,9 +26,8 @@ export class UserFunctions implements IGenerateObject {
                 await this.user_system_functions.generate_object(config);
         }
 
-        // TODO: Add mobile support
         // user_scripts_folder needs to be explicitly set to '/' to query from root
-        if (Platform.isDesktopApp && this.plugin.settings.user_scripts_folder) {
+        if (this.plugin.settings.user_scripts_folder) {
             user_script_functions =
                 await this.user_script_functions.generate_object(config);
         }


### PR DESCRIPTION
There was an issue where if you tried to use user scripts on mobile devices, it would throw an error saying that your script did not exist. It would still detect your user scripts in the settings, but you would not be able to generate any templates. Removing the check to only allow user scripts for desktop seems to have resolved the issue.

This is working for me on my personal Android phone. I am not sure which mobile device caused this to be solely allowed for desktop prior, but it may be that Obsidian has been updated in such a way that the issue has gone away.

fix #586

Changes Made:
- Removed Platform import from Obsidian and using it to check if the current platform is desktop in `UserFunctions.ts`