### PR TITLE
Add option to show/hide Templater ribbon icon

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -39,9 +39,11 @@ export default class TemplaterPlugin extends Plugin {
         this.command_handler.setup();
 
         addIcon("templater-icon", ICON_DATA);
-        this.addRibbonIcon("templater-icon", "Templater", async () => {
-            this.fuzzy_suggester.insert_template();
-        });
+        if(this.settings.enable_ribbon_icon) {
+            this.addRibbonIcon("templater-icon", "Templater", async () => {
+                this.fuzzy_suggester.insert_template();
+            }).setAttribute("id", "rb-templater-icon");
+        }
 
         this.addSettingTab(new TemplaterSettingTab(this.app, this));
 

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -25,6 +25,7 @@ export const DEFAULT_SETTINGS: Settings = {
     syntax_highlighting: true,
     enabled_templates_hotkeys: [""],
     startup_templates: [""],
+    enable_ribbon_icon: true,
 };
 
 export interface Settings {
@@ -41,6 +42,7 @@ export interface Settings {
     syntax_highlighting: boolean;
     enabled_templates_hotkeys: Array<string>;
     startup_templates: Array<string>;
+    enable_ribbon_icon: boolean;
 }
 
 export class TemplaterSettingTab extends PluginSettingTab {
@@ -57,6 +59,7 @@ export class TemplaterSettingTab extends PluginSettingTab {
         this.add_syntax_highlighting_setting();
         this.add_auto_jump_to_cursor();
         this.add_trigger_on_new_file_creation_setting();
+        this.add_ribbon_icon_setting();
         this.add_templates_hotkeys_setting();
         if (this.plugin.settings.trigger_on_file_creation) {
             this.add_folder_templates_setting();
@@ -178,6 +181,34 @@ export class TemplaterSettingTab extends PluginSettingTab {
                         this.plugin.event_handler.update_trigger_file_on_creation();
                         // Force refresh
                         this.display();
+                    });
+            });
+    }
+
+    add_ribbon_icon_setting(): void {
+        const desc = document.createDocumentFragment();
+        desc.append(
+            "Show Templater icon in sidebar ribbon, allowing you to quickly use templates anywhere."
+        );
+
+        new Setting(this.containerEl)
+            .setName("Show icon in sidebar")
+            .setDesc(desc)
+            .addToggle((toggle) => {
+                toggle
+                    .setValue(this.plugin.settings.enable_ribbon_icon)
+                    .onChange((enable_ribbon_icon) => {
+                        this.plugin.settings.enable_ribbon_icon =
+                            enable_ribbon_icon;
+                        this.plugin.save_settings();
+                        if(this.plugin.settings.enable_ribbon_icon) {
+                            this.plugin.addRibbonIcon("templater-icon", "Templater", async () => {
+                                this.fuzzy_suggester.insert_template();
+                            }).setAttribute("id", "rb-templater-icon");
+                        }
+                        else {
+                            document.getElementById("rb-templater-icon")?.remove();
+                        }
                     });
             });
     }


### PR DESCRIPTION
Enhancement #647 I suggested recently.

Add a plugin option to show or hide the sidebar/ribbon icon. There are other ways, including even [another obsidian extension](https://github.com/phibr0/obsidian-customizable-sidebar) with an option to hide the Templater icon. I think it makes more sense and is better for the extension itself to offer that option.

Changes Made:
- Added boolean setting enable_ribbon_icon, default true, toggle option hides/shows icon.
- Added check to see if setting is true before adding icon in main.