### PR TITLE
Updating examples to clarify and simplify

### DIFF
--- a/docs/src/internal-functions/internal-modules/system-module.md
+++ b/docs/src/internal-functions/internal-modules/system-module.md
@@ -31,13 +31,27 @@ Function documentation is using a specific syntax. More information [here](../..
 {%- endfor %}
 
 ## Examples
-
+### Paste from clipboard
 ```javascript
 Clipboard content: <% tp.system.clipboard() %>
-
+```
+### Standard prompt, will return null if cancelled.
+```javascript
 Entered value: <% tp.system.prompt("Please enter a value") %>
+```
+### Same prompt, but will stop the rest of the script if cancelled.
+```javascript
+Entered value: <% tp.system.prompt("Please enter a value", throw_on_cancel = true) %>
+```
+### Ask a question and pre-fill a suggested answer.
+```javascript
 Mood today: <% tp.system.prompt("What is your mood today ?", "happy") %>
-
-Mood today: <% tp.system.suggester(["Happy", "Sad", "Confused"], ["Happy", "Sad", "Confused"]) %>
+```
+### Ask a question and have the user select from a (searchable) list to ensure the correct spelling. 
+```javascript
+Mood today: <% tp.system.suggester(["Happy", "Sad", "Confused"], ["Happy", "Sad", "Confused"], throw_on_cancel = true) %>
+```
+### Have the user select a file from the vault.
+```javascript
 Picked file: [[<% (await tp.system.suggester((item) => item.basename, app.vault.getMarkdownFiles())).basename %>]]
 ```


### PR DESCRIPTION
I spent a lot of time trying to figure out the syntax for using throw_on_cancel because there was no example added when the feature was. 

I've also updated the examples so each one explains a little of what it does making it easier to identify a use case. I think this will make the documentation a lot more accessible to non programmers.