### PR TITLE
Feature: multiline input with `tp.system.prompt`

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "templater-obsidian",
     "name": "Templater",
-    "version": "1.12.0",
+    "version": "1.13.0",
     "description": "Create and use templates",
     "minAppVersion": "0.11.13",
     "author": "SilentVoid",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "templater-obsidian",
     "name": "Templater",
-    "version": "1.13.0",
+    "version": "1.12.0",
     "description": "Create and use templates",
     "minAppVersion": "0.11.13",
     "author": "SilentVoid",

--- a/src/core/functions/internal_functions/system/InternalModuleSystem.ts
+++ b/src/core/functions/internal_functions/system/InternalModuleSystem.ts
@@ -30,20 +30,20 @@ export class InternalModuleSystem extends InternalModule {
     generate_prompt(): (
         prompt_text: string,
         default_value: string,
-        multi_line: boolean,
-        throw_on_cancel: boolean
+        throw_on_cancel: boolean,
+        multi_line: boolean
     ) => Promise<string> {
         return async (
             prompt_text: string,
             default_value: string,
-            widePrompt = false,
-            throw_on_cancel = false
+            throw_on_cancel = false,
+            multi_line = false
         ): Promise<string> => {
             const prompt = new PromptModal(
                 this.app,
                 prompt_text,
                 default_value,
-                widePrompt
+                multi_line
             );
             const promise = new Promise(
                 (

--- a/src/core/functions/internal_functions/system/InternalModuleSystem.ts
+++ b/src/core/functions/internal_functions/system/InternalModuleSystem.ts
@@ -30,17 +30,20 @@ export class InternalModuleSystem extends InternalModule {
     generate_prompt(): (
         prompt_text: string,
         default_value: string,
+        multi_line: boolean,
         throw_on_cancel: boolean
     ) => Promise<string> {
         return async (
             prompt_text: string,
             default_value: string,
+            widePrompt = false,
             throw_on_cancel = false
         ): Promise<string> => {
             const prompt = new PromptModal(
                 this.app,
                 prompt_text,
-                default_value
+                default_value,
+                widePrompt
             );
             const promise = new Promise(
                 (

--- a/src/core/functions/internal_functions/system/PromptModal.ts
+++ b/src/core/functions/internal_functions/system/PromptModal.ts
@@ -56,23 +56,31 @@ export class PromptModal extends Modal {
         textInput.inputEl.addEventListener('keydown', (evt: KeyboardEvent) => this.enterCallback(evt));
     }
 
+    private enterCallback(evt: KeyboardEvent) {
+        if (this.multi_line) {
+            if (Platform.isDesktop) {
+                if (evt.shiftKey && evt.key === "Enter") {
+                } else if (evt.key === "Enter") {
+                    this.resolveAndClose(evt)
+                }
+            } else {
+                // allow pressing enter on mobile for multi-line input
+                if (evt.key === "Enter") {
+                    evt.preventDefault();
+                }
+            }
+        } else {
+            if (evt.key === "Enter") {
+                this.resolveAndClose(evt);
+            }
+        }
+    }
 
-        const form = div.createEl("form");
-        form.addClass("templater-prompt-form");
-        form.type = "submit";
-        form.onsubmit = (e: Event) => {
-            this.submitted = true;
-            e.preventDefault();
-            this.resolve(this.promptEl.value);
-            this.close();
-        };
-
-        this.promptEl = form.createEl("input");
-        this.promptEl.type = "text";
-        this.promptEl.placeholder = "Type text here...";
-        this.promptEl.value = this.default_value ?? "";
-        this.promptEl.addClass("templater-prompt-input");
-        this.promptEl.select();
+    private resolveAndClose(evt: Event|KeyboardEvent) {
+        this.submitted = true;
+        evt.preventDefault();
+        this.resolve(this.value);
+        this.close();
     }
 
     async openAndGetValue(

--- a/styles.css
+++ b/styles.css
@@ -63,6 +63,18 @@
     flex-grow: 1;
 }
 
+.templater-button-div {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-top: 1rem;
+}
+
+textarea.templater-prompt-input {
+    height: 10rem;
+    border-color: var(--interactive-accent);
+}
+
 .cm-s-obsidian .templater-command-bg {
     left: 0px;
     right: 0px;

--- a/styles.css
+++ b/styles.css
@@ -72,6 +72,9 @@
 
 textarea.templater-prompt-input {
     height: 10rem;
+}
+
+textarea.templater-prompt-input:focus {
     border-color: var(--interactive-accent);
 }
 


### PR DESCRIPTION
I've added a new multi-line input prompt inspired by chhoumann/QuickAdd. See [here](https://github.com/chhoumann/quickadd/blob/master/src/gui/GenericWideInputPrompt/GenericWideInputPrompt.ts) for original.

It can be invoked using
```js
let default_value = "Original";
let prompt_text = "Prompt Title Here";
let throw_on_cancel = false;
let multi_line = true;
tR += await tp.system.prompt(prompt_text, default_value, throw_on_cancel, multi_line);
```

Sample:
![image](https://user-images.githubusercontent.com/14124383/179510738-9081c0c9-6840-49db-a7e7-71095561a989.png)

This is an optional variable that shouldn't introduce any breaking changes. I haven't had a chance to test this on mobile.

Note: the event handler for mobile behaves slightly differently. For multi-line inputs, the Submit button must be used as the enter key moves the cursor to the next line.

Please let me know if there's any cleanup I should do.