### PR TITLE
#684 - Remove 'file.stat.size == 0' from line 394

### DIFF
--- a/src/core/Templater.ts
+++ b/src/core/Templater.ts
@@ -391,7 +391,6 @@ export class Templater {
         await delay(300);
 
         if (
-            file.stat.size == 0 &&
             templater.plugin.settings.enable_folder_templates
         ) {
             const folder_template_match =


### PR DESCRIPTION
This line of code means that new files created with the DataBase Folder Plugin do not trigger Templater. Lots of people are trying to use DataBase Folder and Templater together so this pull removes the file size check which enables Templater to trigger.

Related to issue #684 