### PR TITLE
fix issue #691

### DIFF
--- a/src/core/Templater.ts
+++ b/src/core/Templater.ts
@@ -163,7 +163,7 @@ export class Templater {
         });
 
         if (open_new_note) {
-            const active_leaf = this.app.workspace.activeLeaf;
+            const active_leaf = yield this.app.workspace.getLeaf(false);
             if (!active_leaf) {
                 log_error(new TemplaterError("No active leaf"));
                 return;


### PR DESCRIPTION
Instead of getting the activeLeaf from the workspace, which is the File Explorer when you're right-clicking to create a new file from a template, this gets the active leaf from the root split, which is more commonly where you want to be editing. This fix has been validated by myself and two others.