### PR TITLE
delete question template from Issues & remove auto-assign to SilentVoid

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,6 @@ name: Bug report
 about: Create a report to help us improve
 title: ""
 labels: bug
-assignees: SilentVoid13
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,17 +3,16 @@ name: Feature request
 about: Suggest an idea for this project
 title: ""
 labels: enhancement
-assignees: SilentVoid13
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+**Is your feature request related to a problem? Please describe.** A clear and
+concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+**Describe the solution you'd like** A clear and concise description of what you
+want to happen.
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+**Describe alternatives you've considered** A clear and concise description of
+any alternative solutions or features you've considered.
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+**Additional context** Add any other context or screenshots about the feature
+request here.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,7 +1,0 @@
----
-name: Question
-about: Ask a question about Templater
-title: ""
-labels: question
-assignees: SilentVoid13
----


### PR DESCRIPTION
I think questions need to be asked in the Discussions feature and issues should be limited to feature requests and bug reports only.

Also I don't think we should auto-assign all issues to SilentVoid