### PR TITLE
comment out `reject` throwing a new TemplaterError to avoid freezing app

### DIFF
--- a/src/core/functions/internal_functions/system/PromptModal.ts
+++ b/src/core/functions/internal_functions/system/PromptModal.ts
@@ -23,7 +23,9 @@ export class PromptModal extends Modal {
     onClose(): void {
         this.contentEl.empty();
         if (!this.submitted) {
-            this.reject(new TemplaterError("Cancelled prompt"));
+            // TOFIX: for some reason throwing TemplaterError on iOS causes the app to freeze.
+            // this.reject(new TemplaterError("Cancelled prompt"));
+            this.reject();
         }
     }
 


### PR DESCRIPTION
fixes #256 by not calling `new TemplaterError` when rejecting the Modal.