### PR TITLE
Fix for web rand img resizing bug. See #792

### DIFF
--- a/src/core/functions/internal_functions/web/InternalModuleWeb.ts
+++ b/src/core/functions/internal_functions/web/InternalModuleWeb.ts
@@ -59,7 +59,7 @@ export class InternalModuleWeb extends InternalModule {
                     }`
                 );
                 const url = response.url;
-                return `![tp.web.random_picture|${size}](${url})`;
+                return `<img src="${url}" width="100%" height="100%" alt="tp.web.random_picture" contenteditable="false">`;
             } catch (error) {
                 new TemplaterError("Error generating random picture");
                 return "Error generating random picture";


### PR DESCRIPTION
Fix unintended effects (i.e., not respecting previewer and editor padding). See #792
This uses html tag instead of markdown from dbc3df5.
Alternative fix to #793.