### PR TITLE
feat: add optional argument to include size in tp.web.random_picture

### DIFF
--- a/docs/documentation.toml
+++ b/docs/documentation.toml
@@ -323,7 +323,7 @@ definition = "tp.web.daily_quote()"
 [tp.web.functions.random_picture]
 name = "random_picture"
 description = "Gets a random image from https://unsplash.com/"
-definition = "tp.web.random_picture(size?: string, query?: string)"
+definition = "tp.web.random_picture(size?: string, query?: string, include_size?: boolean)"
 
 [tp.web.functions.random_picture.args.size]
 name = "size"
@@ -332,3 +332,7 @@ description = "Image size in the format `<width>x<height>`"
 [tp.web.functions.random_picture.args.query]
 name = "query"
 description = "Limits selection to photos matching a search term. Multiple search terms can be passed separated by a comma `,`"
+
+[tp.web.functions.random_picture.args.include_dimensions]
+name = "include_size"
+description = "Optional argument to include the specified size in the image link markdown. Defaults to false"

--- a/src/core/functions/internal_functions/web/InternalModuleWeb.ts
+++ b/src/core/functions/internal_functions/web/InternalModuleWeb.ts
@@ -49,9 +49,10 @@ export class InternalModuleWeb extends InternalModule {
 
     generate_random_picture(): (
         size: string,
-        query?: string
+        query?: string,
+        include_size?: boolean
     ) => Promise<string> {
-        return async (size: string, query?: string) => {
+        return async (size: string, query?: string, include_size = false) => {
             try {
                 const response = await this.getRequest(
                     `https://source.unsplash.com/random/${size ?? ""}?${
@@ -59,7 +60,10 @@ export class InternalModuleWeb extends InternalModule {
                     }`
                 );
                 const url = response.url;
-                return `![tp.web.random_picture|${size}](${url})`;
+                if (include_size) {
+                    return `![tp.web.random_picture|${size}](${url})`;
+                }
+                return `![tp.web.random_picture](${url})`;
             } catch (error) {
                 new TemplaterError("Error generating random picture");
                 return "Error generating random picture";


### PR DESCRIPTION
fixes #792 
alternative to #793  and #794 

This adds an optional boolean argument to `tp.web.random_picture`: `include_siz`

When true, the size specified in the first argument of the function will be included in the response image markdown:
![image|size](image url)

When false the size won't be included in output. The default value is false to replicate pre 0.13.0 behaviour