### PR TITLE
Fix PromptModal default value needs to be set to this.value on load

### DIFF
--- a/src/core/functions/internal_functions/system/PromptModal.ts
+++ b/src/core/functions/internal_functions/system/PromptModal.ts
@@ -56,9 +56,10 @@ export class PromptModal extends Modal {
             textInput = new TextComponent(div);
         }
 
+        this.value = this.default_value ?? "";
         textInput.inputEl.addClass("templater-prompt-input");
         textInput.setPlaceholder("Type text here");
-        textInput.setValue(this.default_value ?? "");
+        textInput.setValue(this.value);
         textInput.onChange((value) => (this.value = value));
         textInput.inputEl.addEventListener("keydown", (evt: KeyboardEvent) =>
             this.enterCallback(evt)


### PR DESCRIPTION
Issue where it is undefined if you just accept the default string. Happens with all combo of options multi line true/false... error throw true/false. See video.

https://user-images.githubusercontent.com/64155612/189000550-c201fb6c-01ed-4d26-8a9f-eab062308a72.mp4

