### PR TITLE
fix: move on mobile using obsidian api (not path)

### DIFF
--- a/src/core/functions/internal_functions/file/InternalModuleFile.ts
+++ b/src/core/functions/internal_functions/file/InternalModuleFile.ts
@@ -15,7 +15,6 @@ import {
 import { UNSUPPORTED_MOBILE_TEMPLATE } from "utils/Constants";
 import { TemplaterError } from "utils/Error";
 import { ModuleName } from "editor/TpDocumentation";
-import { dirname, sep } from "path";
 
 export const DEPTH_LIMIT = 10;
 
@@ -248,19 +247,14 @@ export class InternalModuleFile extends InternalModule {
             const new_path = normalizePath(
                 `${path}.${file.extension}`
             );
-            
-            // TODO: Add mobile support
-            if (Platform.isMobileApp) {
-                return UNSUPPORTED_MOBILE_TEMPLATE;
+            const dirs = new_path.replace(/\\/g, "/").split("/");
+            dirs.pop(); // remove basename
+            if (dirs.length) {
+                const dir = dirs.join("/");
+                if (!window.app.vault.getAbstractFileByPath(dir)) {
+                    await window.app.vault.createFolder(dir);
+                }
             }
-            if (!(this.app.vault.adapter instanceof FileSystemAdapter)) {
-                throw new TemplaterError(
-                    "app.vault is not a FileSystemAdapter instance"
-                );
-            }
-
-            this.app.vault.adapter.mkdir(dirname(new_path).split(sep).pop());
-
             await this.app.fileManager.renameFile(
                 file,
                 new_path

--- a/tests/InternalTemplates/file/InternalModuleFile.test.ts
+++ b/tests/InternalTemplates/file/InternalModuleFile.test.ts
@@ -171,16 +171,26 @@ export function InternalModuleFileTests(t: TestTemplaterPlugin) {
     t.test("tp.file.move", async () => {
         const saved_target_file = t.target_file;
         const folder_name = `TestFolder`;
+        const nested_name = `TestFolder/nested`;
         const folder = await t.createFolder(folder_name);
         const file1 = await t.createFile(`File1.md`);
+        const nested1 = await t.createFile(`Nested1.md`);
+        
         t.target_file = file1;
-
         await expect(
             t.run_and_get_output(
                 `Move <% tp.file.move("${folder_name}/File2") %>\n\n`
             )
         ).to.eventually.equal(`Move \n\n`);
         expect(file1.path).to.equal(`${folder_name}/File2.md`);
+
+        t.target_file = nested1;
+        await expect(
+            t.run_and_get_output(
+                `Move <% tp.file.move("${nested_name}/Nested2") %>\n\n`
+            )
+        ).to.eventually.equal(`Move \n\n`);
+        expect(nested1.path).to.equal(`${nested_name}/Nested2.md`);
 
         t.target_file = saved_target_file;
         await t.app.vault.delete(folder, true);


### PR DESCRIPTION
Repairs regression to move support on mobile added by #444.

Preserves behavior of second parameter, and ensures target directory exists first.
