### PR TITLE
fix: don't trigger on creation unless new file is opened in a pane

### DIFF
--- a/src/core/Templater.ts
+++ b/src/core/Templater.ts
@@ -399,35 +399,53 @@ export class Templater {
             return;
         }
 
-        // TODO: find a better way to do this
-        // Currently, I have to wait for the daily note plugin to add the file content before replacing
-        // Not a problem with Calendar however since it creates the file with the existing content
-        await delay(300);
+        await new Promise<void>((resolve) => {
+            let timeout: NodeJS.Timeout;
+            const onFileOpenRef = templater.app.workspace.on("file-open", async (openedFile: TAbstractFile) => {
+                if (openedFile !== file) {
+                    return;
+                }
+                clearTimeout(timeout);
+                templater.app.workspace.offref(onFileOpenRef);
 
-        if (
-            file.stat.size == 0 &&
-            templater.plugin.settings.enable_folder_templates
-        ) {
-            const folder_template_match =
-                templater.get_new_file_template_for_folder(file.parent);
-            if (!folder_template_match) {
-                return;
-            }
+                // TODO: find a better way to do this
+                // Currently, I have to wait for the daily note plugin to add the file content before replacing
+                // Not a problem with Calendar however since it creates the file with the existing content
+                await delay(300);
 
-            const template_file: TFile = await errorWrapper(
-                async (): Promise<TFile> => {
-                    return resolve_tfile(templater.app, folder_template_match);
-                },
-                `Couldn't find template ${folder_template_match}`
-            );
-            // errorWrapper failed
-            if (template_file == null) {
-                return;
-            }
-            await templater.write_template_to_file(template_file, file);
-        } else {
-            await templater.overwrite_file_commands(file);
-        }
+                if (
+                    file.stat.size == 0 &&
+                    templater.plugin.settings.enable_folder_templates
+                ) {
+                    const folder_template_match =
+                        templater.get_new_file_template_for_folder(file.parent);
+                    if (!folder_template_match) {
+                        resolve();
+                        return;
+                    }
+
+                    const template_file: TFile = await errorWrapper(
+                        async (): Promise<TFile> => {
+                            return resolve_tfile(templater.app, folder_template_match);
+                        },
+                        `Couldn't find template ${folder_template_match}`
+                    );
+                    // errorWrapper failed
+                    if (template_file == null) {
+                        resolve();
+                        return;
+                    }
+                    await templater.write_template_to_file(template_file, file);
+                } else {
+                    await templater.overwrite_file_commands(file);
+                }
+                resolve();
+            });
+            timeout = setTimeout(() => {
+                templater.app.workspace.offref(onFileOpenRef);
+                resolve();
+            }, 300);
+        });
     }
 
     async execute_startup_scripts(): Promise<void> {

--- a/src/core/Templater.ts
+++ b/src/core/Templater.ts
@@ -400,13 +400,14 @@ export class Templater {
         }
 
         await new Promise<void>((resolve) => {
-            let timeout: NodeJS.Timeout;
-            const onFileOpenRef = templater.app.workspace.on("file-open", async (openedFile: TAbstractFile) => {
-                if (openedFile !== file) {
+            // eslint-disable-next-line prefer-const
+            let timeout: number;
+            const file_open_ref = templater.app.workspace.on("file-open", async (opened_file: TFile) => {
+                if (opened_file !== file) {
                     return;
                 }
-                clearTimeout(timeout);
-                templater.app.workspace.offref(onFileOpenRef);
+                window.clearTimeout(timeout);
+                templater.app.workspace.offref(file_open_ref);
 
                 // TODO: find a better way to do this
                 // Currently, I have to wait for the daily note plugin to add the file content before replacing
@@ -441,8 +442,8 @@ export class Templater {
                 }
                 resolve();
             });
-            timeout = setTimeout(() => {
-                templater.app.workspace.offref(onFileOpenRef);
+            timeout = window.setTimeout(() => {
+                templater.app.workspace.offref(file_open_ref);
                 resolve();
             }, 300);
         });


### PR DESCRIPTION
See my comment from https://github.com/SilentVoid13/Templater/issues/716#issuecomment-1242573930

- I've done a bit of testing but would appreciate others verify that this doesn't break anything. I am not familiar with this codebase.
- I chose `300ms` as the max threshold between file creation and opening - works on my machine, but not sure if it might break on slower machines?
- I wonder if a similar event+timeout approach could be used to eliminate the need for the `await delay(300)`

Fixes #716, fixes #554