### PR TITLE
fix: strip any comments from being parsed

### DIFF
--- a/src/core/parser/Parser.ts
+++ b/src/core/parser/Parser.ts
@@ -5,6 +5,7 @@ export class Parser {
         content: string,
         object: Record<string, unknown>
     ): Promise<string> {
+        content = content.replace(/\/\/.*\n/g, "");
         content = (await renderAsync(content, object, {
             varName: "tp",
             parse: {


### PR DESCRIPTION
A naive approach that looks for any lines starting with `//` and removes them before parsing starts.

fixes: #728 