### PR TITLE
fix: change to new unsplash api

### DIFF
--- a/src/core/functions/internal_functions/web/InternalModuleWeb.ts
+++ b/src/core/functions/internal_functions/web/InternalModuleWeb.ts
@@ -55,15 +55,23 @@ export class InternalModuleWeb extends InternalModule {
         return async (size: string, query?: string, include_size = false) => {
             try {
                 const response = await this.getRequest(
-                    `https://source.unsplash.com/random/${size ?? ""}?${
-                        query ?? ""
+                    `https://templater-unsplash.fly.dev/${
+                        query ? "?q=" + query : ""
                     }`
-                );
-                const url = response.url;
-                if (include_size) {
-                    return `![tp.web.random_picture|${size}](${url})`;
+                ).then((res) => res.json());
+                let url = response.full;
+                if (size && !include_size) {
+                    if (size.includes("x")) {
+                        const [width, height] = size.split("x");
+                        url = url.concat(`&w=${width}&h=${height}`);
+                    } else {
+                        url = url.concat(`&w=${size}`);
+                    }
                 }
-                return `![tp.web.random_picture](${url})`;
+                if (include_size) {
+                    return `![photo by ${response.photog} on Unsplash|${size}](${url})`;
+                }
+                return `![photo by ${response.photog} on Unsplash](${url})`;
             } catch (error) {
                 new TemplaterError("Error generating random picture");
                 return "Error generating random picture";


### PR DESCRIPTION
This PR changes the old and now deprecated Unsplash API endpoint to the new unsplash API.

Because the new API requires authentication, I created a small express add hosted at https://templater-unsplash.fly.dev/ which acts as a proxy for the unsplash api. This way the Auth Key won't be exposed on the client.

The server-side code can be reviewed here: https://github.com/shabegom/templater-unsplash-proxy

The one potential issue is that the API has a rate limit of 50 images per hour unless you apply for production-level access. Some of the API guidelines make production-level access undesirable. To try and loosely adhere to the guidelines, the text of a random_picture will now include attribution to the photographer.