### PR TITLE
Fix tp.file.exists() example

### DIFF
--- a/docs/src/internal-functions/internal-modules/file-module.md
+++ b/docs/src/internal-functions/internal-modules/file-module.md
@@ -45,7 +45,7 @@ File cursor: <% tp.file.cursor(1) %>
 
 File cursor append: <% tp.file.cursor_append("Some text") %>
     
-File existence: <% tp.file.exists("MyFile") %>
+File existence: <% await tp.file.exists("MyFolder/MyFile.md") %>
 
 File find TFile: <% tp.file.find_tfile("MyFile").basename %>
     


### PR DESCRIPTION
tp.file.exists() is async, but the docs are not reflecting that. Also it requires full path as an argument to avoid collisions of files with same name in different folders