### PR TITLE
Escape apostrophes and keywords in examples in docs closes #852

### DIFF
--- a/docs/src/internal-functions/internal-modules/date-module.md
+++ b/docs/src/internal-functions/internal-modules/date-module.md
@@ -39,25 +39,25 @@ More information on moment.js [here](https://momentjs.com/docs/#/displaying/)
 ## Examples
 
 ```javascript
-Date now: <% tp.date.now() %>
-Date now with format: <% tp.date.now("Do MMMM YYYY") %>
+<pre>Date now: </pre><% tp.date.now() %>
+<pre>Date now with format: </pre><% tp.date.now("Do MMMM YYYY") %>
 
-Last week: <% tp.date.now("dddd Do MMMM YYYY", -7) %>
-Today: <% tp.date.now("dddd Do MMMM YYYY, ddd") %>
-Next week: <% tp.date.now("dddd Do MMMM YYYY", 7) %>
+<pre>Last week: </pre><% tp.date.now("dddd Do MMMM YYYY", -7) %>
+<pre>Today: </pre><% tp.date.now("dddd Do MMMM YYYY, ddd") %>
+<pre>Next week: </pre><% tp.date.now("dddd Do MMMM YYYY", 7) %>
 
-Last month: <% tp.date.now("YYYY-MM-DD", "P-1M") %>
-Next year: <% tp.date.now("YYYY-MM-DD", "P1Y") %>
+<pre>Last month: </pre><% tp.date.now("YYYY-MM-DD", "P-1M") %>
+<pre>Next year: </pre><% tp.date.now("YYYY-MM-DD", "P1Y") %>
 
-File's title date + 1 day (tomorrow): <% tp.date.now("YYYY-MM-DD", 1, tp.file.title, "YYYY-MM-DD") %>
-File's title date - 1 day (yesterday): <% tp.date.now("YYYY-MM-DD", -1, tp.file.title, "YYYY-MM-DD") %>
+<pre>File's title date + 1 day (tomorrow): </pre><% tp.date.now("YYYY-MM-DD", 1, tp.file.title, "YYYY-MM-DD") %>
+<pre>File's title date - 1 day (yesterday): </pre><% tp.date.now("YYYY-MM-DD", -1, tp.file.title, "YYYY-MM-DD") %>
 
-Date tomorrow with format: <% tp.date.tomorrow("Do MMMM YYYY") %>    
+<pre>Date tomorrow with format: </pre><% tp.date.tomorrow("Do MMMM YYYY") %>    
 
-This week's monday: <% tp.date.weekday("YYYY-MM-DD", 0) %>
-Next monday: <% tp.date.weekday("YYYY-MM-DD", 7) %>
-File's title monday: <% tp.date.weekday("YYYY-MM-DD", 0, tp.file.title, "YYYY-MM-DD") %>
-File's title next monday: <% tp.date.weekday("YYYY-MM-DD", 7, tp.file.title, "YYYY-MM-DD") %>
+<pre>This week's monday: </pre><% tp.date.weekday("YYYY-MM-DD", 0) %>
+<pre>Next monday: </pre><% tp.date.weekday("YYYY-MM-DD", 7) %>
+<pre>File's title monday: </pre><% tp.date.weekday("YYYY-MM-DD", 0, tp.file.title, "YYYY-MM-DD") %>
+<pre>File's title next monday: </pre><% tp.date.weekday("YYYY-MM-DD", 7, tp.file.title, "YYYY-MM-DD") %>
 
-Date yesterday with format: <% tp.date.yesterday("Do MMMM YYYY") %>
+<pre>Date yesterday with format: </pre><% tp.date.yesterday("Do MMMM YYYY") %>
 ```

--- a/docs/src/internal-functions/internal-modules/file-module.md
+++ b/docs/src/internal-functions/internal-modules/file-module.md
@@ -34,42 +34,42 @@ Function documentation is using a specific syntax. More information [here](../..
 ## Examples
 
 ```javascript
-File content: <% tp.file.content %>
+<pre>File content: </pre><% tp.file.content %>
 
-File creation date: <% tp.file.creation_date() %>
-File creation date with format: <% tp.file.creation_date("dddd Do MMMM YYYY HH:mm") %>
+<pre>File creation date: </pre><% tp.file.creation_date() %>
+<pre>File creation date with format: </pre><% tp.file.creation_date("dddd Do MMMM YYYY HH:mm") %>
 
-File creation: [[<% (await tp.file.create_new("MyFileContent", "MyFilename")).basename %>]]
+<pre>File creation: </pre>[[<% (await tp.file.create_new("MyFileContent", "MyFilename")).basename %>]]
 
-File cursor: <% tp.file.cursor(1) %>
+<pre>File cursor: </pre><% tp.file.cursor(1) %>
 
-File cursor append: <% tp.file.cursor_append("Some text") %>
-    
-File existence: <% await tp.file.exists("MyFolder/MyFile.md") %>
+<pre>File cursor append: </pre><% tp.file.cursor_append("Some text") %>
 
-File find TFile: <% tp.file.find_tfile("MyFile").basename %>
-    
-File Folder: <% tp.file.folder() %>
-File Folder with relative path: <% tp.file.folder(true) %>
+<pre>File existence: </pre><% await tp.file.exists("MyFolder/MyFile.md") %>
 
-File Include: <% tp.file.include("[[Template1]]") %>
+<pre>File find TFile: </pre><% tp.file.find_tfile("MyFile").basename %>
 
-File Last Modif Date: <% tp.file.last_modified_date() %>
-File Last Modif Date with format: <% tp.file.last_modified_date("dddd Do MMMM YYYY HH:mm") %>
+<pre>File Folder: </pre><% tp.file.folder() %>
+<pre>File Folder with relative path: </pre><% tp.file.folder(true) %>
 
-File Move: <% await tp.file.move("/A/B/" + tp.file.title) %>
-File Move + Rename: <% await tp.file.move("/A/B/NewTitle") %>
+<pre>File Include: </pre><% tp.file.include("[[Template1]]") %>
 
-File Path: <% tp.file.path() %>
-File Path with relative path: <% tp.file.path(true) %>
+<pre>File Last Modif Date: </pre><% tp.file.last_modified_date() %>
+<pre>File Last Modif Date with format: </pre><% tp.file.last_modified_date("dddd Do MMMM YYYY HH:mm") %>
 
-File Rename: <% await tp.file.rename("MyNewName") %>
-Append a "2": <% await tp.file.rename(tp.file.title + "2") %>
+<pre>File Move: </pre><% await tp.file.move("/A/B/" + tp.file.title) %>
+<pre>File Move + Rename: </pre><% await tp.file.move("/A/B/NewTitle") %>
 
-File Selection: <% tp.file.selection() %>
+<pre>File Path: </pre><% tp.file.path() %>
+<pre>File Path with relative path: </pre><% tp.file.path(true) %>
 
-File tags: <% tp.file.tags %>
+<pre>File Rename: </pre><% await tp.file.rename("MyNewName") %>
+<pre>Append a "2": </pre><% await tp.file.rename(tp.file.title + "2") %>
 
-File title: <% tp.file.title %>
-Strip the Zettelkasten ID of title (if space separated): <% tp.file.title.split(" ")[1] %>
+<pre>File Selection: </pre><% tp.file.selection() %>
+
+<pre>File tags: </pre><% tp.file.tags %>
+
+<pre>File title: </pre><% tp.file.title %>
+<pre>Strip the Zettelkasten ID of title (if space separated): </pre><% tp.file.title.split(" ")[1] %>
 ```

--- a/docs/src/internal-functions/internal-modules/file-module.md
+++ b/docs/src/internal-functions/internal-modules/file-module.md
@@ -44,11 +44,11 @@ Function documentation is using a specific syntax. More information [here](../..
 <pre>File cursor: </pre><% tp.file.cursor(1) %>
 
 <pre>File cursor append: </pre><% tp.file.cursor_append("Some text") %>
-
+    
 <pre>File existence: </pre><% await tp.file.exists("MyFolder/MyFile.md") %>
 
 <pre>File find TFile: </pre><% tp.file.find_tfile("MyFile").basename %>
-
+    
 <pre>File Folder: </pre><% tp.file.folder() %>
 <pre>File Folder with relative path: </pre><% tp.file.folder(true) %>
 

--- a/docs/src/internal-functions/internal-modules/frontmatter-module.md
+++ b/docs/src/internal-functions/internal-modules/frontmatter-module.md
@@ -31,7 +31,7 @@ file content
 
 Then you can use the following template:
 
-````
-File's metadata alias: <% tp.frontmatter.alias %>
-Note's type: <% tp.frontmatter["note type"] %>
+````javascript
+<pre>File's metadata alias: </pre><% tp.frontmatter.alias %>
+<pre>Note's type: </pre><% tp.frontmatter["note type"] %>
 ````

--- a/docs/src/internal-functions/internal-modules/system-module.md
+++ b/docs/src/internal-functions/internal-modules/system-module.md
@@ -39,5 +39,5 @@ Function documentation is using a specific syntax. More information [here](../..
 <pre>Mood today: </pre><% tp.system.prompt("What is your mood today ?", "happy") %>
 
 <pre>Mood today: </pre><% tp.system.suggester(["Happy", "Sad", "Confused"], ["Happy", "Sad", "Confused"]) %>
-<pre>Picked file: [[</pre><% (await tp.system.suggester((item) => item.basename, app.vault.getMarkdownFiles())).basename %>]]
+<pre>Picked file: </pre>[[<% (await tp.system.suggester((item) => item.basename, app.vault.getMarkdownFiles())).basename %>]]
 ```

--- a/docs/src/internal-functions/internal-modules/system-module.md
+++ b/docs/src/internal-functions/internal-modules/system-module.md
@@ -33,11 +33,11 @@ Function documentation is using a specific syntax. More information [here](../..
 ## Examples
 
 ```javascript
-Clipboard content: <% tp.system.clipboard() %>
+<pre>Clipboard content: </pre><% tp.system.clipboard() %>
 
-Entered value: <% tp.system.prompt("Please enter a value") %>
-Mood today: <% tp.system.prompt("What is your mood today ?", "happy") %>
+<pre>Entered value: </pre><% tp.system.prompt("Please enter a value") %>
+<pre>Mood today: </pre><% tp.system.prompt("What is your mood today ?", "happy") %>
 
-Mood today: <% tp.system.suggester(["Happy", "Sad", "Confused"], ["Happy", "Sad", "Confused"]) %>
-Picked file: [[<% (await tp.system.suggester((item) => item.basename, app.vault.getMarkdownFiles())).basename %>]]
+<pre>Mood today: </pre><% tp.system.suggester(["Happy", "Sad", "Confused"], ["Happy", "Sad", "Confused"]) %>
+<pre>Picked file: [[</pre><% (await tp.system.suggester((item) => item.basename, app.vault.getMarkdownFiles())).basename %>]]
 ```

--- a/docs/src/internal-functions/internal-modules/web-module.md
+++ b/docs/src/internal-functions/internal-modules/web-module.md
@@ -33,15 +33,15 @@ Function documentation is using a specific syntax. More information [here](../..
 ## Examples
 
 ```javascript
-Web Daily quote:  
+<pre>Web Daily quote: </pre>
 <% tp.web.daily_quote() %>
 
-Web Random picture: 
+<pre>Web Random picture: </pre>
 <% tp.web.random_picture() %>
 
-Web Random picture with size: 
+<pre>Web Random picture with size: </pre>
 <% tp.web.random_picture("200x200") %>
 
-Web random picture with size + query: 
+<pre>Web random picture with size + query: </pre>
 <% tp.web.random_picture("200x200", "landscape,water") %>
 ```


### PR DESCRIPTION
Use \<pre\> tag to escape all content that is not meant to have syntax highlighting.
Add syntax highlighting to frontmatter-module.
Closes #852 