### PR TITLE
Add docs-dev script for running mdbooks locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "pretest": "eslint --ignore-path .gitignore src/",
         "test-build": "node esbuild.config.mjs production test",
         "test-dev": "node esbuild.config.mjs test",
+        "docs-dev": "mdbook serve docs",
         "commit": "cz",
         "release": "standard-version -t ''"
     },


### PR DESCRIPTION
To run this script requires installing mdbooks following the steps here https://rust-lang.github.io/mdBook/guide/installation.html

We may want to consider adding some documentation (in the README or elsewhere) to explain that there needs to be an installation process first.

I don't think we'd want to add an script to install mdbooks, since we may not know where the user wants to install the binary, but if y'all feel otherwise I can add an install script, just think it needs some discussion first before we add that.