### PR TITLE
fix: parsing freezes on large files

### DIFF
--- a/src/core/Templater.ts
+++ b/src/core/Templater.ts
@@ -419,7 +419,11 @@ export class Templater {
             }
             await templater.write_template_to_file(template_file, file);
         } else {
-            await templater.overwrite_file_commands(file);
+            if(file.stat.size <= 10000) { //https://github.com/SilentVoid13/Templater/issues/873
+                await templater.overwrite_file_commands(file);
+            } else {
+                console.log(`Templater skipped parsing ${file.path} because file size exceeds 10000`);
+            }
         }
     }
 


### PR DESCRIPTION
A hard coded fix for #873.

Based on a quick analysis of my vault, I propose to hard coded file size limit of 10000 to skip the on file create parsing of large files.

I have 5675 markdown files in my vault. Over 90% percent of these have a size below the proposed 10000 size limit.
