### PR TITLE
Bug: tp.file.exists in Obsidian v1.0.0 always returns false for files;

### DIFF
--- a/docs/documentation.toml
+++ b/docs/documentation.toml
@@ -161,7 +161,7 @@ description = "The content to append after the active cursor"
 
 [tp.file.functions.exists]
 name = "exists"
-description = "Checks if a file exists or not. Returns a true / false boolean."
+description = "The filename of the file we want to check existence. The fullpath to the file, relative to the Vault and containing the extension, must be provided. e.g. MyFolder/SubFolder/MyFile."
 definition = "tp.file.exists(filename: string)"
 
 [tp.file.functions.exists.args.filename]

--- a/docs/src/internal-functions/internal-modules/file-module.md
+++ b/docs/src/internal-functions/internal-modules/file-module.md
@@ -46,6 +46,7 @@ File cursor: <% tp.file.cursor(1) %>
 File cursor append: <% tp.file.cursor_append("Some text") %>
     
 File existence: <% await tp.file.exists("MyFolder/MyFile.md") %>
+File existence of current file: <% await tp.file.exists(tp.file.folder(true)+"/"+tp.file.title+".md") %>
 
 File find TFile: <% tp.file.find_tfile("MyFile").basename %>
     

--- a/src/core/functions/internal_functions/file/InternalModuleFile.ts
+++ b/src/core/functions/internal_functions/file/InternalModuleFile.ts
@@ -129,7 +129,7 @@ export class InternalModuleFile extends InternalModule {
     generate_exists(): (filename: string) => Promise<boolean> {
         return async (filename: string) => {
             const path = normalizePath(filename);
-            return app.metadataCache.getFirstLinkpathDest(path, "");
+            return await app.vault.exists(path);
         };
     }
 

--- a/src/core/functions/internal_functions/file/InternalModuleFile.ts
+++ b/src/core/functions/internal_functions/file/InternalModuleFile.ts
@@ -128,7 +128,8 @@ export class InternalModuleFile extends InternalModule {
 
     generate_exists(): (filename: string) => Promise<boolean> {
         return async (filename: string) => {
-            return await app.vault.exists(filename);
+            const path = normalizePath(filename);
+            return app.metadataCache.getFirstLinkpathDest(path, "");
         };
     }
 


### PR DESCRIPTION
Addresses #878 in 2 ways:
1) Fixes documentation to reflect that tp.file.exists requires a full path. 
2) Adds a call to normalizePath() inside exists() function so that templates can work across Windows and *nix OS'. 
