### PR TITLE
Set activeFile to newly created note

### DIFF
--- a/src/core/Templater.ts
+++ b/src/core/Templater.ts
@@ -124,7 +124,10 @@ export class Templater {
             folder,
             filename ?? "Untitled"
         );
-
+        
+        // Set activeFile to newly created note
+        await app.workspace.getLeaf(false).openFile(created_note, { state: { mode: "source" }, })
+        
         let running_config: RunningConfig;
         let output_content: string;
         if (template instanceof TFile) {


### PR DESCRIPTION
This allows plugins using app.workspace.getActiveFile() to be called … from template

I am using a plugin that I call via the command 
```
<% app.workspace.executeCommandById("lol") %>
```

and that plugin uses the current_file, I have no power over that and wanted this to work like for new daily notes made via the core plugin.

This allows the `Create new note from template` to behave like the new daily note.