### PR TITLE
fix: syntax highlighting breaks live preview on mobile.

### DIFF
--- a/src/editor/Editor.ts
+++ b/src/editor/Editor.ts
@@ -30,10 +30,15 @@ export class Editor {
 
     async setup(): Promise<void> {
         await this.registerCodeMirrorMode();
-        this.plugin.registerEditorSuggest(new Autocomplete(app));
-        this.plugin.registerEditorExtension(
-            StreamLanguage.define(window.CodeMirror.getMode({}, { name: 'templater' }) as any)
-        )
+        this.plugin.registerEditorSuggest(new Autocomplete());
+    // only enable syntax highlighting on desktop because it breaks live preview on mobile
+        if (Platform.isDesktopApp) {
+            this.plugin.registerEditorExtension(
+                StreamLanguage.define(
+                    window.CodeMirror.getMode({}, { name: "templater" }) as any
+                )
+            );
+        }
     }
 
     async jump_to_next_cursor_location(


### PR DESCRIPTION
Disables syntax highlighting on mobile devices because it seems to break live preview rendering.