### PR TITLE
Added content to help files. Await on tp.system cmds

### DIFF
--- a/docs/src/commands/execution-command.md
+++ b/docs/src/commands/execution-command.md
@@ -24,7 +24,7 @@ For example, the following command: `<%* tR += "test" %>` will output `test`.
 
 ### Suggesters and Prompts
 
-It is important to note that the `tp.system.prompt()` and `tp.system.suggester()` both requrire a `await` statment to save the value to a variable
+It is important to note that the `tp.system.prompt()` and `tp.system.suggester()` both require a `await` statment to save the value to a variable
 
 ## Examples
 

--- a/docs/src/internal-functions/internal-modules/system-module.md
+++ b/docs/src/internal-functions/internal-modules/system-module.md
@@ -43,7 +43,7 @@ Picked file: [[<% (await tp.system.suggester((item) => item.basename, app.vault.
 
 
 <%*
-const execution_value = tp.system.suggester(["Yes", "No"], ["true", "false"])
+const execution_value = await tp.system.suggester(["Yes", "No"], ["true", "false"])
 %>
 Are you using Execution Commands: <%*  tR + execution_value %>
 

--- a/docs/src/internal-functions/internal-modules/system-module.md
+++ b/docs/src/internal-functions/internal-modules/system-module.md
@@ -40,4 +40,11 @@ Mood today: <% tp.system.prompt("What is your mood today ?", "happy") %>
 
 Mood today: <% tp.system.suggester(["Happy", "Sad", "Confused"], ["Happy", "Sad", "Confused"]) %>
 Picked file: [[<% (await tp.system.suggester((item) => item.basename, app.vault.getMarkdownFiles())).basename %>]]
+
+
+<%*
+const execution_value = tp.system.suggester(["Yes", "No"], ["true", "false"])
+%>
+Are you using Execution Commands: <%*  tR + execution_value %>
+
 ```


### PR DESCRIPTION
Currently, the Execution commands cannot save the output of a suggester or prompt to a variable w/o an await. Added an example and some content about the change.