### PR TITLE
chore: fix spelling mistake

### DIFF
--- a/docs/src/commands/execution-command.md
+++ b/docs/src/commands/execution-command.md
@@ -24,7 +24,7 @@ For example, the following command: `<%* tR += "test" %>` will output `test`.
 
 ### Suggesters and Prompts
 
-It is important to note that the `tp.system.prompt()` and `tp.system.suggester()` both require a `await` statment to save the value to a variable
+It is important to note that the `tp.system.prompt()` and `tp.system.suggester()` both require a `await` statement to save the value to a variable
 
 ## Examples
 


### PR DESCRIPTION
quick fix spelling error I didn't catch in the last docs merge