### PR TITLE
Fix tp.config.template_file documentation

### DIFF
--- a/docs/documentation.toml
+++ b/docs/documentation.toml
@@ -8,7 +8,7 @@ This is mostly useful when writing scripts requiring some context information.
 [tp.config.functions.template_file]
 name = "template_file"
 description = "The `TFile` object representing the template file."
-definition = "tp.file.template_file"
+definition = "tp.config.template_file"
 
 [tp.config.functions.target_file]
 name = "target_file"


### PR DESCRIPTION
The function is in the tp.config module, but the documentation mentions as tp.**file**.