### PR TITLE
Allow many more cursors

### DIFF
--- a/src/editor/CursorJumper.ts
+++ b/src/editor/CursorJumper.ts
@@ -60,7 +60,7 @@ export class CursorJumper {
         let cursor_matches = [];
         let match;
         const cursor_regex = new RegExp(
-            "<%\\s*tp.file.cursor\\((?<order>[0-9]{0,2})\\)\\s*%>",
+            "<%\\s*tp.file.cursor\\((?<order>[0-9]*)\\)\\s*%>",
             "g"
         );
 


### PR DESCRIPTION
Instead of just allowing between 0-2 characters for tp.file.cursor, allow as many characters as the user wants.
This fixes #956.