### PR TITLE
Fix mobile focus on prompt

### DIFF
--- a/src/core/functions/internal_functions/system/PromptModal.ts
+++ b/src/core/functions/internal_functions/system/PromptModal.ts
@@ -59,6 +59,7 @@ export class PromptModal extends Modal {
         textInput.setPlaceholder("Type text here");
         textInput.setValue(this.value);
         textInput.onChange((value) => (this.value = value));
+        textInput.inputEl.focus();
         textInput.inputEl.addEventListener("keydown", (evt: KeyboardEvent) =>
             this.enterCallback(evt)
         );


### PR DESCRIPTION
add .focus on inputEl on PromptModal 
fixes mobile focus on prompt creation
before it would try to open kb, but closes after a ms