### PR TITLE
Fix autocomplete user functions

### DIFF
--- a/src/editor/Autocomplete.ts
+++ b/src/editor/Autocomplete.ts
@@ -7,6 +7,7 @@ import {
     MarkdownView,
     TFile,
 } from "obsidian";
+import { Settings } from "settings/Settings";
 
 import {
     Documentation,
@@ -28,9 +29,9 @@ export class Autocomplete extends EditorSuggest<TpSuggestDocumentation> {
     private function_trigger: boolean;
     private function_name: string;
 
-    constructor() {
+    constructor(settings: Settings) {
         super(app);
-        this.documentation = new Documentation();
+        this.documentation = new Documentation(settings);
     }
 
     onTrigger(

--- a/src/editor/Editor.ts
+++ b/src/editor/Editor.ts
@@ -39,7 +39,7 @@ export class Editor {
 
     async setup(): Promise<void> {
         await this.registerCodeMirrorMode();
-        this.plugin.registerEditorSuggest(new Autocomplete());
+        this.plugin.registerEditorSuggest(new Autocomplete(this.plugin.settings));
 
         // Selectively enable syntax highlighting via per-platform preferences.
         if (this.desktopShouldHighlight() || this.mobileShouldHighlight()) {

--- a/src/editor/TpDocumentation.ts
+++ b/src/editor/TpDocumentation.ts
@@ -1,3 +1,6 @@
+import { Settings } from "settings/Settings";
+import { errorWrapperSync } from "utils/Error";
+import { get_tfiles_from_folder } from "utils/Utils";
 import documentation from "../../docs/documentation.toml";
 
 const module_names = [
@@ -62,7 +65,7 @@ export function is_function_documentation(
 export class Documentation {
     public documentation: TpDocumentation = documentation;
 
-    constructor() {}
+    constructor(private settings: Settings) {}
 
     get_all_modules_documentation(): TpModuleDocumentation[] {
         return Object.values(this.documentation.tp);
@@ -71,6 +74,29 @@ export class Documentation {
     get_all_functions_documentation(
         module_name: ModuleName
     ): TpFunctionDocumentation[] | undefined {
+        if (module_name === "user") {
+            if (!this.settings || !this.settings.user_scripts_folder) return;
+            const files = errorWrapperSync(
+                () => get_tfiles_from_folder(this.settings.user_scripts_folder),
+                `User Scripts folder doesn't exist`
+            );
+            if (!files || files.length === 0) return;
+            return files.reduce<TpFunctionDocumentation[]>(
+                (processedFiles, file) => {
+                    if (file.extension !== "js") return processedFiles;
+                    return [
+                        ...processedFiles,
+                        {
+                            name: file.basename,
+                            definition: "",
+                            description: "",
+                            example: "",
+                        },
+                    ];
+                },
+                []
+            );
+        }
         if (!this.documentation.tp[module_name].functions) {
             return;
         }


### PR DESCRIPTION
This fixes #840 by returning the files in the user's user_scripts_folder as autocomplete suggestions.

Future enhancement: Support adding other documentation parameters (description, example, etc.)