### PR TITLE
Add url_only option to random_picture to improve plugin compability

### DIFF
--- a/docs/documentation.toml
+++ b/docs/documentation.toml
@@ -324,7 +324,7 @@ definition = "tp.web.daily_quote()"
 [tp.web.functions.random_picture]
 name = "random_picture"
 description = "Gets a random image from https://unsplash.com/"
-definition = "tp.web.random_picture(size?: string, query?: string, include_size?: boolean, raw_output?: boolean)"
+definition = "tp.web.random_picture(size?: string, query?: string, include_size?: boolean, url_only?: boolean)"
 
 [tp.web.functions.random_picture.args.size]
 name = "size"
@@ -338,6 +338,6 @@ description = "Limits selection to photos matching a search term. Multiple searc
 name = "include_size"
 description = "Optional argument to include the specified size in the image link markdown. Defaults to false"
 
-[tp.web.functions.random_picture.args.raw_output]
-name = "raw_output"
-description = "Optional argument to return the raw image link instead of the markdown. Defaults to false"
+[tp.web.functions.random_picture.args.url_only]
+name = "url_only"
+description = "Optional argument to return only the url image link instead of the markdown. Defaults to false"

--- a/docs/documentation.toml
+++ b/docs/documentation.toml
@@ -324,7 +324,7 @@ definition = "tp.web.daily_quote()"
 [tp.web.functions.random_picture]
 name = "random_picture"
 description = "Gets a random image from https://unsplash.com/"
-definition = "tp.web.random_picture(size?: string, query?: string, include_size?: boolean)"
+definition = "tp.web.random_picture(size?: string, query?: string, include_size?: boolean, raw_output?: boolean)"
 
 [tp.web.functions.random_picture.args.size]
 name = "size"
@@ -337,3 +337,7 @@ description = "Limits selection to photos matching a search term. Multiple searc
 [tp.web.functions.random_picture.args.include_dimensions]
 name = "include_size"
 description = "Optional argument to include the specified size in the image link markdown. Defaults to false"
+
+[tp.web.functions.random_picture.args.raw_output]
+name = "raw_output"
+description = "Optional argument to return the raw image link instead of the markdown. Defaults to false"

--- a/src/core/functions/internal_functions/web/InternalModuleWeb.ts
+++ b/src/core/functions/internal_functions/web/InternalModuleWeb.ts
@@ -50,9 +50,10 @@ export class InternalModuleWeb extends InternalModule {
     generate_random_picture(): (
         size: string,
         query?: string,
-        include_size?: boolean
+        include_size?: boolean,
+        raw_output?: boolean
     ) => Promise<string> {
-        return async (size: string, query?: string, include_size = false) => {
+        return async (size: string, query?: string, include_size = false, raw_output = false) => {
             try {
                 const response = await this.getRequest(
                     `https://templater-unsplash.fly.dev/${
@@ -67,6 +68,9 @@ export class InternalModuleWeb extends InternalModule {
                     } else {
                         url = url.concat(`&w=${size}`);
                     }
+                }
+                if(raw_output) {
+                    return url;
                 }
                 if (include_size) {
                     return `![photo by ${response.photog} on Unsplash|${size}](${url})`;

--- a/src/core/functions/internal_functions/web/InternalModuleWeb.ts
+++ b/src/core/functions/internal_functions/web/InternalModuleWeb.ts
@@ -51,9 +51,9 @@ export class InternalModuleWeb extends InternalModule {
         size: string,
         query?: string,
         include_size?: boolean,
-        raw_output?: boolean
+        url_only?: boolean
     ) => Promise<string> {
-        return async (size: string, query?: string, include_size = false, raw_output = false) => {
+        return async (size: string, query?: string, include_size = false, url_only = false) => {
             try {
                 const response = await this.getRequest(
                     `https://templater-unsplash.fly.dev/${
@@ -69,7 +69,7 @@ export class InternalModuleWeb extends InternalModule {
                         url = url.concat(`&w=${size}`);
                     }
                 }
-                if(raw_output) {
+                if(url_only) {
                     return url;
                 }
                 if (include_size) {


### PR DESCRIPTION
This patch adds a url_only option to `tf.web.random_picture()` to enable better compatibility with other plugins, i.e. Banners. This value defaults to `false` to maintain the current behavior. Documentation has been updated to add this option.