### PR TITLE
Add option to show relative paths instead of only filenames

### DIFF
--- a/src/handlers/FuzzySuggester.ts
+++ b/src/handlers/FuzzySuggester.ts
@@ -35,7 +35,15 @@ export class FuzzySuggester extends FuzzySuggestModal<TFile> {
     }
 
     getItemText(item: TFile): string {
-        return item.basename;
+         if (this.plugin.settings.display_full_paths) {
+            let relativePath = item.path
+            if(this.plugin.settings.templates_folder && item.path.startsWith(this.plugin.settings.templates_folder)) {
+                relativePath = item.path.slice(this.plugin.settings.templates_folder.length+1)
+            }
+            return relativePath.split(".").slice(0, -1).join(".");
+        } else {
+            return item.basename;
+        }
     }
 
     onChooseItem(item: TFile): void {

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -28,6 +28,7 @@ export const DEFAULT_SETTINGS: Settings = {
     enabled_templates_hotkeys: [""],
     startup_templates: [""],
     enable_ribbon_icon: true,
+    display_full_paths: false,
 };
 
 export interface Settings {
@@ -46,6 +47,7 @@ export interface Settings {
     enabled_templates_hotkeys: Array<string>;
     startup_templates: Array<string>;
     enable_ribbon_icon: boolean;
+    display_full_paths: boolean;
 }
 
 export class TemplaterSettingTab extends PluginSettingTab {
@@ -71,6 +73,7 @@ export class TemplaterSettingTab extends PluginSettingTab {
         this.add_user_script_functions_setting();
         this.add_user_system_command_functions_setting();
         this.add_donating_setting();
+        this.add_full_path_display_setting();
     }
 
     add_general_setting_header(): void {
@@ -92,6 +95,20 @@ export class TemplaterSettingTab extends PluginSettingTab {
                 // @ts-ignore
                 cb.containerEl.addClass("templater_search");
             });
+    }
+
+    add_full_path_display_setting(): void {
+        new Setting(this.containerEl)
+            .setName("Display full path")
+            .setDesc("Toggle to display the full path of templates in the list instead of relative path")
+            .addToggle((toggle) =>
+                toggle
+                    .setValue(this.plugin.settings.display_full_paths)
+                    .onChange(async (value) => {
+                        this.plugin.settings.display_full_paths = value;
+                        await this.plugin.save_settings();
+                    })
+            );
     }
 
     add_internal_functions_setting(): void {


### PR DESCRIPTION
Personally I have templates grouped by categories in different folders and it's inconvenient to select the template by looking only on its filename. So I added an option to include the subfolders in the templates list