### PR TITLE
Add a basic date picker modal

### DIFF
--- a/src/core/functions/internal_functions/date/DatePickerModal.ts
+++ b/src/core/functions/internal_functions/date/DatePickerModal.ts
@@ -1,0 +1,71 @@
+import { TemplaterError } from "utils/Error";
+import {
+    ButtonComponent,
+    Modal,
+    moment
+} from "obsidian";
+
+export class DateModal extends Modal {
+    private resolve: (value: string) => void;
+    private reject: (reason?: TemplaterError) => void;
+    private submitted = false;
+    private value: string;
+
+    constructor(
+        private title: string,
+        private format: string,
+    ) {
+        super(app);
+        this.value = moment().format(format);
+    }
+
+    onOpen(): void {
+        this.titleEl.setText(this.title);
+        this.createForm();
+    }
+
+    onClose(): void {
+        this.contentEl.empty();
+        if (!this.submitted) {
+            // TOFIX: for some reason throwing TemplaterError on iOS causes the app to freeze.
+            // this.reject(new TemplaterError("Cancelled prompt"));
+            this.reject();
+        }
+    }
+
+    createForm(): void {
+        const div = this.contentEl.createDiv();
+        div.addClass("templater-date-div");
+        const datePicker = this.contentEl.createEl("input");
+        datePicker.type = "date";
+        const buttonDiv = this.contentEl.createDiv();
+        buttonDiv.addClass("templater-button-div");
+        const submitButton = new ButtonComponent(buttonDiv);
+        submitButton.buttonEl.addClass("mod-cta");
+        submitButton.setButtonText("Submit").onClick((evt: Event) => {
+            this.resolveAndClose(evt);
+        });
+
+        datePicker.addClass("templater-prompt-input");
+        datePicker.value = this.value;
+        datePicker.addEventListener("input", (event) => {
+            this.value = moment((event.target as HTMLInputElement)?.valueAsDate).format(this.format) || moment().format(this.format);
+        });
+    }
+
+    private resolveAndClose(evt: Event | KeyboardEvent) {
+        this.submitted = true;
+        evt.preventDefault();
+        this.resolve(this.value);
+        this.close();
+    }
+
+    async openAndGetValue(
+        resolve: (value: string) => void,
+        reject: (reason?: TemplaterError) => void
+    ): Promise<void> {
+        this.resolve = resolve;
+        this.reject = reject;
+        this.open();
+    }
+}

--- a/src/core/functions/internal_functions/date/InternalModuleDate.ts
+++ b/src/core/functions/internal_functions/date/InternalModuleDate.ts
@@ -1,6 +1,7 @@
 import { TemplaterError } from "utils/Error";
 import { InternalModule } from "../InternalModule";
 import { ModuleName } from "editor/TpDocumentation";
+import { DateModal } from "./DatePickerModal";
 
 export class InternalModuleDate extends InternalModule {
     public name: ModuleName = "date";
@@ -10,6 +11,7 @@ export class InternalModuleDate extends InternalModule {
         this.static_functions.set("tomorrow", this.generate_tomorrow());
         this.static_functions.set("weekday", this.generate_weekday());
         this.static_functions.set("yesterday", this.generate_yesterday());
+        this.static_functions.set("date_picker", this.generate_date_picker());
     }
 
     async create_dynamic_templates(): Promise<void> {}
@@ -84,6 +86,37 @@ export class InternalModuleDate extends InternalModule {
     generate_yesterday(): (format?: string) => string {
         return (format = "YYYY-MM-DD") => {
             return window.moment().add(-1, "days").format(format);
+        };
+    }
+
+    generate_date_picker(): (
+        title: string,
+        placeholder: string,
+        throw_on_cancel: boolean,
+    ) => Promise<string> {
+        return async (
+            title: string,
+            format = "YYYY-MM-DD",
+            throw_on_cancel = false
+        ): Promise<string> => {
+            const datePicker = new DateModal(
+                title,
+                format
+            );
+            const promise = new Promise(
+                (
+                    resolve: (value: any) => void,
+                    reject: (reason?: TemplaterError) => void
+                ) => datePicker.openAndGetValue(resolve, reject)
+            );
+            try {
+                return await promise;
+            } catch (error) {
+                if (throw_on_cancel) {
+                    throw error;
+                }
+                return null as any;
+            }
         };
     }
 }


### PR DESCRIPTION
Preview:
<img width="569" alt="image" src="https://user-images.githubusercontent.com/14124383/233795472-ce747042-6e1f-4e13-9fee-4cd34e015579.png">


- [ ] Add tests
- [ ] Fix CSS
- [ ] Add docs

Notes:
- I chose to add this under `tp.date` since it seems to fit in nicely.
- How can I make a release on my repo so that I can continue to use it via BRAT? It appears the workflow needs me to merge this into main and Obsidian also looks for the `package.json` in `master` and incrementing the version number on another package would cause the regular installation to fail. I committed it to my personal branch since once it's merged, it's easier to pull in the new master rather than having to rebase or deal with other shenanigans.