### PR TITLE
fix: define app.dom

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,9 @@
 declare module "obsidian" {
-    interface dom {
-        appContainerEl: HTMLElement;
-    }
+    interface App {
+        dom: {
+          appContainerEl: HTMLElement;
+        }
+      }
 
     interface Vault {
         getConfig: (key: string) => string;


### PR DESCRIPTION
in `suggest.ts`, there's an error message "Property 'dom' does not exist on type 'App'." in [line 153](https://github.com/SilentVoid13/Templater/src/settings/suggesters/suggest.ts#L153)

this patch fixes the issue