### PR TITLE
Allow executing templates in notes in .canvas files

### DIFF
--- a/src/core/Templater.ts
+++ b/src/core/Templater.ts
@@ -256,16 +256,16 @@ export class Templater {
     }
 
     overwrite_active_file_commands(): void {
-        const active_view = app.workspace.getActiveViewOfType(MarkdownView);
-        if (active_view === null) {
+        const active_editor = app.workspace.activeEditor;
+        if (!active_editor || !active_editor.file) {
             log_error(
                 new TemplaterError(
-                    "Active view is null, can't overwrite content"
+                    "Active editor is null, can't overwrite content"
                 )
             );
             return;
         }
-        this.overwrite_file_commands(active_view.file, true);
+        this.overwrite_file_commands(active_editor.file, true);
     }
 
     async overwrite_file_commands(

--- a/src/core/Templater.ts
+++ b/src/core/Templater.ts
@@ -59,7 +59,7 @@ export class Templater {
         target_file: TFile,
         run_mode: RunMode
     ): RunningConfig {
-        const active_file = app.workspace.getActiveFile();
+        const active_file = app.workspace.activeEditor?.file;
 
         return {
             template_file: template_file,
@@ -103,7 +103,7 @@ export class Templater {
             const new_file_location = app.vault.getConfig("newFileLocation");
             switch (new_file_location) {
                 case "current": {
-                    const active_file = app.workspace.getActiveFile();
+                    const active_file = app.workspace.activeEditor?.file;
                     if (active_file) {
                         folder = active_file.parent;
                     }

--- a/src/core/functions/internal_functions/file/InternalModuleFile.ts
+++ b/src/core/functions/internal_functions/file/InternalModuleFile.ts
@@ -4,7 +4,6 @@ import { log_error } from "utils/Log";
 import {
     FileSystemAdapter,
     getAllTags,
-    MarkdownView,
     normalizePath,
     parseLinktext,
     Platform,
@@ -109,17 +108,17 @@ export class InternalModuleFile extends InternalModule {
 
     generate_cursor_append(): (content: string) => void {
         return (content: string): string | undefined => {
-            const active_view = app.workspace.getActiveViewOfType(MarkdownView);
-            if (active_view === null) {
+            const active_editor = app.workspace.activeEditor;
+            if (!active_editor || !active_editor.editor) {
                 log_error(
                     new TemplaterError(
-                        "No active view, can't append to cursor."
+                        "No active editor, can't append to cursor."
                     )
                 );
                 return;
             }
 
-            const editor = active_view.editor;
+            const editor = active_editor.editor;
             const doc = editor.getDoc();
             doc.replaceSelection(content);
             return "";
@@ -289,14 +288,14 @@ export class InternalModuleFile extends InternalModule {
 
     generate_selection(): () => string {
         return () => {
-            const active_view = app.workspace.getActiveViewOfType(MarkdownView);
-            if (active_view == null) {
+            const active_editor = app.workspace.activeEditor;
+            if (!active_editor || !active_editor.editor) {
                 throw new TemplaterError(
-                    "Active view is null, can't read selection."
+                    "Active editor is null, can't read selection."
                 );
             }
 
-            const editor = active_view.editor;
+            const editor = active_editor.editor;
             return editor.getSelection();
         };
     }

--- a/src/editor/Autocomplete.ts
+++ b/src/editor/Autocomplete.ts
@@ -4,7 +4,6 @@ import {
     EditorSuggest,
     EditorSuggestContext,
     EditorSuggestTriggerInfo,
-    MarkdownView,
     TFile,
 } from "obsidian";
 
@@ -102,12 +101,12 @@ export class Autocomplete extends EditorSuggest<TpSuggestDocumentation> {
         value: TpSuggestDocumentation,
         _evt: MouseEvent | KeyboardEvent
     ): void {
-        const active_view = app.workspace.getActiveViewOfType(MarkdownView);
-        if (!active_view) {
+        const active_editor = app.workspace.activeEditor;
+        if (!active_editor || !active_editor.editor) {
             // TODO: Error msg
             return;
         }
-        active_view.editor.replaceRange(
+        active_editor.editor.replaceRange(
             value.name,
             this.latest_trigger_info.start,
             this.latest_trigger_info.end
@@ -120,7 +119,7 @@ export class Autocomplete extends EditorSuggest<TpSuggestDocumentation> {
             // Not sure what's the cause of this bug.
             const cursor_pos = this.latest_trigger_info.end;
             cursor_pos.ch += value.name.length;
-            active_view.editor.setCursor(cursor_pos);
+            active_editor.editor.setCursor(cursor_pos);
         }
     }
 }

--- a/src/editor/CursorJumper.ts
+++ b/src/editor/CursorJumper.ts
@@ -2,7 +2,6 @@ import {
     EditorPosition,
     EditorRangeOrCaret,
     EditorTransaction,
-    MarkdownView,
 } from "obsidian";
 import { escape_RegExp } from "utils/Utils";
 
@@ -10,30 +9,26 @@ export class CursorJumper {
     constructor() {}
 
     async jump_to_next_cursor_location(): Promise<void> {
-        const active_view = app.workspace.getActiveViewOfType(MarkdownView);
-        if (!active_view) {
+        const active_editor = app.workspace.activeEditor;
+        if (!active_editor || !active_editor.editor) {
             return;
         }
-        const active_file = active_view.file;
-        await active_view.save();
-
-        const content = await app.vault.read(active_file);
+        const content = active_editor.editor.getValue();
 
         const { new_content, positions } =
             this.replace_and_get_cursor_positions(content);
         if (positions) {
-            await app.vault.modify(active_file, new_content as string);
+            active_editor.editor.setValue(new_content as string);
             this.set_cursor_location(positions);
         }
 
         // enter insert mode for vim users
         if (app.vault.getConfig("vimMode")) {
-           // @ts-ignore
-           const cm = active_view.editor.cm.cm
-           // @ts-ignore
-           window.CodeMirrorAdapter.Vim.handleKey(cm, "i", "mapping")
+            // @ts-ignore
+            const cm = active_editor.editor.cm.cm;
+            // @ts-ignore
+            window.CodeMirrorAdapter.Vim.handleKey(cm, "i", "mapping");
         }
-
     }
 
     get_editor_position_from_index(
@@ -102,12 +97,12 @@ export class CursorJumper {
     }
 
     set_cursor_location(positions: EditorPosition[]): void {
-        const active_view = app.workspace.getActiveViewOfType(MarkdownView);
-        if (!active_view) {
+        const active_editor = app.workspace.activeEditor;
+        if (!active_editor || !active_editor.editor) {
             return;
         }
 
-        const editor = active_view.editor;
+        const editor = active_editor.editor;
 
         const selections: Array<EditorRangeOrCaret> = [];
         for (const pos of positions) {

--- a/src/editor/Editor.ts
+++ b/src/editor/Editor.ts
@@ -58,7 +58,7 @@ export class Editor {
         if (auto_jump && !this.plugin.settings.auto_jump_to_cursor) {
             return;
         }
-        if (file && app.workspace.getActiveFile() !== file) {
+        if (file && app.workspace.activeEditor?.file !== file) {
             return;
         }
         await this.cursor_jumper.jump_to_next_cursor_location();


### PR DESCRIPTION
Allow executing templates in notes in `.canvas` files (fixes #1034).

1. Replace all instances of `app.workspace.getActiveViewOfType()` with `app.workspace.activeEditor`.
2. Replace all instances of `app.workspace.getActiveFile()` with `app.workspace.activeEditor?.file`.