### PR TITLE
Enhance Quote Formatting and Semantic Correctness in `generate_daily_quote`

### DIFF
--- a/src/core/functions/internal_functions/web/InternalModuleWeb.ts
+++ b/src/core/functions/internal_functions/web/InternalModuleWeb.ts
@@ -37,7 +37,7 @@ export class InternalModuleWeb extends InternalModule {
 
                 const author = json.author;
                 const quote = json.content;
-                const new_content = `> ${quote}\n> — ${author}`;
+                const new_content = `> [!quote] ${quote}\n> — ${author}`;
 
                 return new_content;
             } catch (error) {

--- a/src/core/functions/internal_functions/web/InternalModuleWeb.ts
+++ b/src/core/functions/internal_functions/web/InternalModuleWeb.ts
@@ -37,7 +37,7 @@ export class InternalModuleWeb extends InternalModule {
 
                 const author = json.author;
                 const quote = json.content;
-                const new_content = `> ${quote}\n> — <cite>${author}</cite>`;
+                const new_content = `> ${quote}\n> — ${author}`;
 
                 return new_content;
             } catch (error) {


### PR DESCRIPTION
This PR proposes two changes to the `generate_daily_quote` function:

1. Removal of the `<cite>` element from quote formatting. According to the HTML specification, the <cite> tag defines the title of a creative work (e.g., a book, a poem, a song, a movie, etc.), and it's not intended for citing individuals. Therefore, this change aligns with best practices for HTML and semantic web.

2. Update of quote formatting to use Obsidian callouts. This change provides a more visually appealing and distinguishable format for quotes compared to the generic markdown quote syntax within Obsidian. (With this change, the author’s name stays on a new line, even with strict line breaks enabled.)

Original:
![](https://i.imgur.com/zc2oerL.png)

Proposed:
![](https://i.imgur.com/jXvoS3z.png)

Here are the original and proposed changes:

Original:
```typescript
const new_content = `> ${quote}\n> — <cite>${author}</cite>`;
```

Proposed:
```typescript
const new_content = `> [!quote] ${quote}\n> — ${author}`;
```