### PR TITLE
Replace var declaration with let declaration

### DIFF
--- a/src/editor/mode/custom_overlay.js
+++ b/src/editor/mode/custom_overlay.js
@@ -95,7 +95,7 @@
             },
 
             blankLine: function (state) {
-                var baseToken, overlayToken;
+                let baseToken, overlayToken;
                 if (base.blankLine) baseToken = base.blankLine(state.base);
                 if (overlay.blankLine)
                     overlayToken = overlay.blankLine(state.overlay);


### PR DESCRIPTION
Replace `var` declaration with `let` declaration. `let` is used much more frequently in this repository.