### PR TITLE
Force the priority higher to override hypermd

### DIFF
--- a/src/editor/Editor.ts
+++ b/src/editor/Editor.ts
@@ -10,8 +10,10 @@ import { Autocomplete } from "editor/Autocomplete";
 import "editor/mode/javascript";
 import "editor/mode/custom_overlay";
 import { StreamLanguage } from "@codemirror/language";
-import { Prec } from "@codemirror/state";
+import { Extension, Prec } from "@codemirror/state";
 //import "editor/mode/show-hint";
+
+const TEMPLATER_MODE_NAME = "templater";
 
 const TP_CMD_TOKEN_CLASS = "templater-command";
 const TP_INLINE_CLASS = "templater-inline";
@@ -24,9 +26,14 @@ const TP_EXEC_TAG_TOKEN_CLASS = "templater-execution-tag";
 
 export class Editor {
     private cursor_jumper: CursorJumper;
+    private activeEditorExtensions: Array<Extension>;
+
+    // Note that this is `undefined` until `setup` has run.
+    private templaterLanguage: Extension | undefined;
 
     public constructor(private plugin: TemplaterPlugin) {
         this.cursor_jumper = new CursorJumper();
+        this.activeEditorExtensions = [];
     }
 
     desktopShouldHighlight(): boolean {
@@ -40,14 +47,51 @@ export class Editor {
     }
 
     async setup(): Promise<void> {
-        await this.registerCodeMirrorMode();
         this.plugin.registerEditorSuggest(new Autocomplete(this.plugin.settings));
+
+        // We define our overlay as a stand-alone extension and keep a reference
+        // to it around. This lets us dynamically turn it on and off as needed.
+        await this.registerCodeMirrorMode();
+        this.templaterLanguage = Prec.high(
+            StreamLanguage.define(window.CodeMirror.getMode({}, TEMPLATER_MODE_NAME) as any)
+        );
+        if (this.templaterLanguage === undefined) {
+            log_error(
+                new TemplaterError(
+                    "Unable to enable syntax highlighting. Could not define language."
+                )
+            )
+        }
+
+        // Dynamic reconfiguration is now done by passing an array. If we modify
+        // that array and then call `Workspace.updateOptions` the new extension
+        // will be picked up.
+        this.plugin.registerEditorExtension(this.activeEditorExtensions);
 
         // Selectively enable syntax highlighting via per-platform preferences.
         if (this.desktopShouldHighlight() || this.mobileShouldHighlight()) {
-            this.plugin.registerEditorExtension(Prec.high(
-                StreamLanguage.define(window.CodeMirror.getMode({}, "templater") as any))
-            );
+            await this.enable_highlighter();
+        }
+    }
+
+    async enable_highlighter(): Promise<void> {
+        // Make sure it is idempotent
+        if (this.activeEditorExtensions.length === 0 && this.templaterLanguage) {
+            // There should only ever be this one extension if the array is not
+            // empty.
+            this.activeEditorExtensions.push(this.templaterLanguage);
+            // This is expensive
+            this.plugin.app.workspace.updateOptions();
+        }
+    }
+
+    async disable_highlighter(): Promise<void> {
+        // Make sure that it is idempotent.
+        if (this.activeEditorExtensions.length > 0) {
+            // There should only ever be one extension if the array is not empty.
+            this.activeEditorExtensions.pop()
+            // This is expensive
+            this.plugin.app.workspace.updateOptions();
         }
     }
 
@@ -58,7 +102,7 @@ export class Editor {
         if (auto_jump && !this.plugin.settings.auto_jump_to_cursor) {
             return;
         }
-        if (file && get_active_file(app) !== file) {
+        if (file && get_active_file(this.plugin.app) !== file) {
             return;
         }
         await this.cursor_jumper.jump_to_next_cursor_location();
@@ -98,7 +142,7 @@ export class Editor {
             return;
         }
 
-        window.CodeMirror.defineMode("templater", function (config) {
+        window.CodeMirror.defineMode(TEMPLATER_MODE_NAME, function (config) {
             const templaterOverlay = {
                 startState: function () {
                     const js_state = window.CodeMirror.startState(js_mode) as Object;

--- a/src/editor/Editor.ts
+++ b/src/editor/Editor.ts
@@ -10,6 +10,7 @@ import { Autocomplete } from "editor/Autocomplete";
 import "editor/mode/javascript";
 import "editor/mode/custom_overlay";
 import { StreamLanguage } from "@codemirror/language";
+import { Prec } from "@codemirror/state";
 //import "editor/mode/show-hint";
 
 const TP_CMD_TOKEN_CLASS = "templater-command";
@@ -44,10 +45,8 @@ export class Editor {
 
         // Selectively enable syntax highlighting via per-platform preferences.
         if (this.desktopShouldHighlight() || this.mobileShouldHighlight()) {
-            this.plugin.registerEditorExtension(
-                StreamLanguage.define(
-                    window.CodeMirror.getMode({}, { name: "templater" }) as any
-                )
+            this.plugin.registerEditorExtension(Prec.high(
+                StreamLanguage.define(window.CodeMirror.getMode({}, "templater") as any))
             );
         }
     }
@@ -102,7 +101,7 @@ export class Editor {
         window.CodeMirror.defineMode("templater", function (config) {
             const templaterOverlay = {
                 startState: function () {
-                    const js_state = window.CodeMirror.startState(js_mode);
+                    const js_state = window.CodeMirror.startState(js_mode) as Object;
                     return {
                         ...js_state,
                         inCommand: false,
@@ -111,7 +110,7 @@ export class Editor {
                     };
                 },
                 copyState: function (state: any) {
-                    const js_state = window.CodeMirror.startState(js_mode);
+                    const js_state = window.CodeMirror.startState(js_mode) as Object;
                     const new_state = {
                         ...js_state,
                         inCommand: state.inCommand,


### PR DESCRIPTION
Fixes the broken highlighting in `1.5.x`. Changes internally had changed the priority of the default `hypermd` highlighter, so when the Templater mode was created it was lower priority.

In this PR I force it to use `Prec.high(...)` and hence when it's enabled it now works. It also changes things to use the new mechanism for loading and unloading the highlighter, given the old one has been removed entirely. The toggles in settings still work in real-time.

Finally, I should note that it will no longer work in the CM5 editor, but given that this is removed by Obsidian 1.5.x I do not think this is a problem.

Many thanks to Licat for the pointer regarding the priority changes!

Closes #1251 