### PR TITLE
To resolve warnings I get when using Node12 (actions/checkout)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     gh-release:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
               with:
                 fetch-depth: 0
             - name: Install mdbook

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     build:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - uses: denolib/setup-deno@v2
               with:
                   deno-version: v1.x


### PR DESCRIPTION
The version of each action has been brought up to date at this time.

warning is below

![image](https://github.com/SilentVoid13/Templater/assets/4104038/af15a909-1867-4b9f-aa5c-cbba73bedb91)

This PR is for `actions/checkout`.