### PR TITLE
Update Templater.ts

### DIFF
--- a/src/core/Templater.ts
+++ b/src/core/Templater.ts
@@ -253,8 +253,9 @@ export class Templater {
         const oldSelections = doc.listSelections();
         doc.replaceSelection(output_content);
         // Refresh editor to ensure properties widget shows after inserting template in blank file
-        await app.vault.append(active_editor.file, "");
-
+        if(active_editor.file){
+          await app.vault.append(active_editor.file, "");
+        }
         app.workspace.trigger("templater:template-appended", {
             view: active_view,
             editor: active_editor,


### PR DESCRIPTION
included check for null active editor before appending blank string. See docs: https://docs.obsidian.md/Reference/TypeScript+API/Workspace/activeEditor

This mitigates edge cases where blank string is appended during transition between active editors. Fixes #1309 