### PR TITLE
docs: Fix broken example of a Script User Function

### DIFF
--- a/docs/src/user-functions/script-user-functions.md
+++ b/docs/src/user-functions/script-user-functions.md
@@ -26,7 +26,7 @@ module.exports = my_function;
 In this example, a complete command invocation would look like this: 
 
 ```javascript
-<% tp.user.my_script("Hello World!") %>
+<% tp.user.my_function("Hello World!") %>
 ```
 
 Which would output `Message from my script: Hello World!`.


### PR DESCRIPTION
The current example fails, giving:
my_functiontp.user.my_script is not a function