### PR TITLE
Added copy_from_file and copy_from_folder functions

### DIFF
--- a/src/core/functions/internal_functions/file/InternalModuleFile.ts
+++ b/src/core/functions/internal_functions/file/InternalModuleFile.ts
@@ -28,6 +28,8 @@ export class InternalModuleFile extends InternalModule {
             this.generate_creation_date()
         );
         this.static_functions.set("create_new", this.generate_create_new());
+        this.static_functions.set("copy_from_file", this.generate_copy_from_file());
+        this.static_functions.set("copy_from_folder", this.generate_copy_from_folder());
         this.static_functions.set("cursor", this.generate_cursor());
         this.static_functions.set(
             "cursor_append",
@@ -53,7 +55,7 @@ export class InternalModuleFile extends InternalModule {
         this.dynamic_functions.set("title", this.generate_title());
     }
 
-    async teardown(): Promise<void> {}
+    async teardown(): Promise<void> { }
 
     async generate_content(): Promise<string> {
         return await app.vault.read(this.config.target_file);
@@ -92,6 +94,80 @@ export class InternalModuleFile extends InternalModule {
             return new_file;
         };
     }
+
+    generate_copy_from_file(): (
+        copyfile: string,
+        destfolder: string,
+        filename: string,
+        open_new: boolean,
+    ) => Promise<TFile | undefined> {
+        return async (
+            copyfile: string,
+            destfolder: string,
+            filename: string,
+            open_new: boolean,
+        ) => {
+            console.log("Doing copy stuff in InternalModuleFile");
+            this.create_new_depth += 1;
+            if (this.create_new_depth > DEPTH_LIMIT) {
+                this.create_new_depth = 0;
+                throw new TemplaterError(
+                    "Reached create_new depth limit (max = 10)"
+                );
+            }
+
+            const new_file =
+                await this.plugin.templater.copy_note_from_file(
+                    copyfile,
+                    destfolder,
+                    filename,
+                    open_new
+                );
+
+            this.create_new_depth -= 1;
+
+            return new_file;
+        };
+    }
+
+    generate_copy_from_folder(): (
+        sourcefolder: string,
+        copystrategy: string,
+        destfolder: string,
+        filename: string,
+        open_new: boolean,
+    ) => Promise<TFile | undefined> {
+        return async (
+            sourcefolder: string,
+            copystrategy: string,
+            destfolder: string,
+            filename: string,
+            open_new: boolean,
+        ) => {
+            console.log("Doing copy stuff in InternalModuleFile");
+            this.create_new_depth += 1;
+            if (this.create_new_depth > DEPTH_LIMIT) {
+                this.create_new_depth = 0;
+                throw new TemplaterError(
+                    "Reached create_new depth limit (max = 10)"
+                );
+            }
+
+            const new_file =
+                await this.plugin.templater.copy_note_from_folder(
+                    sourcefolder,
+                    copystrategy,
+                    destfolder,
+                    filename,
+                    open_new,
+                );
+
+            this.create_new_depth -= 1;
+
+            return new_file;
+        };
+    }
+
 
     generate_creation_date(): (format?: string) => string {
         return (format = "YYYY-MM-DD HH:mm") => {


### PR DESCRIPTION
This PR adds two functions: `copy_from_file` and `copy_from_folder`.

# Goal 

These functions allow users to take already existing files with full content and copy them to a new location. Some use case for this include: Maintain a record of your notes over time, Copy the latest to do list you have to a new folder so you can update its existing content easily, Copy latest status sync info, 'Template' with existing notes, Use the content you already have in an existing note and keep that up to date, copy new associated files and link to them in your templated note, and more!

# Sample usage

Copy the latest modified file from one folder to another

`<%* await tp.file.copy_from_folder("Status Sync", "lastModified","Status Sync") %>`

Snapshot a particular file and link to it

`Todo snapshot: [[<% (await tp.file.copy_from_file("Todos.md", "Snapshots", "Todo-" + tp.date.now("YYYY-MM-DD"))).basename %>]]`

# Improvements

This PR needs improvements for these areas. If the initial idea looks good please let me know and then I can finish coding in rest of the required items which I believe are:

- [ ] Add documentation
- [ ] Add test coverage


