### PR TITLE
Return Relative Paths of Templates in Fuzzy Suggester Prompt

### DIFF
--- a/src/handlers/FuzzySuggester.ts
+++ b/src/handlers/FuzzySuggester.ts
@@ -35,7 +35,13 @@ export class FuzzySuggester extends FuzzySuggestModal<TFile> {
     }
 
     getItemText(item: TFile): string {
-        return item.basename;
+        let relativePath = item.path;
+        if (item.path.startsWith(this.plugin.settings.templates_folder)) {
+            relativePath = item.path.slice(
+                this.plugin.settings.templates_folder.length + 1
+            );
+        }
+        return relativePath.split(".").slice(0, -1).join(".");
     }
 
     onChooseItem(item: TFile): void {


### PR DESCRIPTION
This pull request builds upon the work done by @DraggonFantasy in https://github.com/SilentVoid13/Templater/pull/1078. It includes the following additional changes:
- Removes settings, and removes requirements for settings in `getItemText()` func

Credit to @DraggonFantasy for the initial work.

Fixes https://github.com/SilentVoid13/Templater/issues/1223