### PR TITLE
Sort Files by Path

### DIFF
--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -63,7 +63,7 @@ export function get_tfiles_from_folder(folder_str: string): Array<TFile> {
     });
 
     files.sort((a, b) => {
-        return a.basename.localeCompare(b.basename);
+        return a.path.localeCompare(b.path);
     });
 
     return files;


### PR DESCRIPTION
An oversight within https://github.com/SilentVoid13/Templater/pull/1418.

Now sorts suggestor files by path as apposed to solely basename. 

Before:
![image](https://github.com/user-attachments/assets/1559cde5-cd08-487c-b06f-3afa7f8e89fb)

After: 
![image](https://github.com/user-attachments/assets/47497f9d-3c90-460e-9b6c-27ac233dc133)

---

This is a great feature, because ultimately, it simply uses the folder structure that matches the templates folder. So if you want to keep a single flat heierarchy, have no folders!