### PR TITLE
fix(1446): updates docs to match _actual_ behaviour of tp.file.folder()

### DIFF
--- a/docs/documentation.toml
+++ b/docs/documentation.toml
@@ -318,18 +318,18 @@ example = """<% tp.file.find_tfile("MyFile").basename %>"""
 [tp.file.functions.folder]
 name = "folder"
 description = "Retrieves the file's folder name."
-definition = "tp.file.folder(relative: boolean = false)"
+definition = "tp.file.folder(absolute: boolean = false)"
 
 [[tp.file.functions.folder.args]]
-name = "relative"
-description = "If set to `true`, appends the vault relative path to the folder name. If `false`, only retrieves name of folder. Defaults to `false`."
+name = "absolute"
+description = "If set to `true`, returns the vault-absolute path of the folder. If `false`, only returns the basename of the folder (the last part). Defaults to `false`."
 
 [[tp.file.functions.folder.examples]]
 name = "File folder (Folder)"
 example = "<% tp.file.folder() %>"
 
 [[tp.file.functions.folder.examples]]
-name = "File folder with relative path (Path/To/Folder)"
+name = "File folder with vault-absolute path (Path/To/Folder)"
 example = "<% tp.file.folder(true) %>"
 
 [tp.file.functions.include]

--- a/src/core/functions/internal_functions/file/InternalModuleFile.ts
+++ b/src/core/functions/internal_functions/file/InternalModuleFile.ts
@@ -141,12 +141,12 @@ export class InternalModuleFile extends InternalModule {
         };
     }
 
-    generate_folder(): (relative?: boolean) => string {
-        return (relative = false) => {
+    generate_folder(): (absolute?: boolean) => string {
+        return (absolute = false) => {
             const parent = this.config.target_file.parent;
             let folder;
 
-            if (relative) {
+            if (absolute) {
                 folder = parent.path;
             } else {
                 folder = parent.name;


### PR DESCRIPTION
This should clarify behaviour whilst preserving back-compatibility.

This is a best-of solution that will hold until a better one is developed.

fixes #1446 