### PR TITLE
fix: Change API provider for daily quotes

### DIFF
--- a/src/core/functions/internal_functions/web/InternalModuleWeb.ts
+++ b/src/core/functions/internal_functions/web/InternalModuleWeb.ts
@@ -34,12 +34,12 @@ export class InternalModuleWeb extends InternalModule {
         return async () => {
             try {
                 const response = await this.getRequest(
-                    "https://api.quotable.io/random"
+                    "https://zenquotes.io/api/today"
                 );
                 const json = await response.json();
 
-                const author = json.author;
-                const quote = json.content;
+                const author = json.a;
+                const quote = json.q;
                 const new_content = `> [!quote] ${quote}\n> — ${author}`;
 
                 return new_content;


### PR DESCRIPTION
## Overview
The Quotable API has been unreachable due to SSL cert expiration since approximately June, with no sign of progress from the package matainers (see [Issues in lukePeavey/quotable)](https://github.com/lukePeavey/quotable/issues?q=is%3Aissue+is%3Aopen+label%3A%22%3Awarning%3A+API+is+down%22)). To restore functionality for daily quotes, this patch changes the provider API over to [Zenquotes](https://docs.zenquotes.io/zenquotes-documentation/#api-structure).

Resolves #1407 

## Notes
- This patch uses the `/daily` endpoint from Zenquotes, which does not perfectly match the functionality of the random Quotable endpoint, in the manner that it returns the same quote for a given 24 hour timespan. This seems to match more with the intended use of this function, but if there is concern about keeping quotes perfectly random per call to Templater, this can be switched over to `/random`