### PR TITLE
Streamline folder template UX

### DIFF
--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -1,11 +1,10 @@
+import TemplaterPlugin from "main";
 import { ButtonComponent, PluginSettingTab, Setting } from "obsidian";
 import { errorWrapperSync, TemplaterError } from "utils/Error";
-import { FolderSuggest } from "./suggesters/FolderSuggester";
-import { FileSuggest, FileSuggestMode } from "./suggesters/FileSuggester";
-import TemplaterPlugin from "main";
-import { arraymove, get_tfiles_from_folder } from "utils/Utils";
 import { log_error } from "utils/Log";
-import { HEART, PAYPAL } from "utils/Constants";
+import { arraymove, get_tfiles_from_folder } from "utils/Utils";
+import { FileSuggest, FileSuggestMode } from "./suggesters/FileSuggester";
+import { FolderSuggest } from "./suggesters/FolderSuggester";
 
 export interface FolderTemplate {
     folder: string;
@@ -367,24 +366,6 @@ export class TemplaterSettingTab extends PluginSettingTab {
             return;
         }
 
-        new Setting(this.containerEl)
-            .setName("Add new")
-            .setDesc("Add new folder template")
-            .addButton((button: ButtonComponent) => {
-                button
-                    .setTooltip("Add additional folder template")
-                    .setButtonText("+")
-                    .setCta()
-                    .onClick(() => {
-                        this.plugin.settings.folder_templates.push({
-                            folder: "",
-                            template: "",
-                        });
-                        this.plugin.save_settings();
-                        this.display();
-                    });
-            });
-
         this.plugin.settings.folder_templates.forEach(
             (folder_template, index) => {
                 const s = new Setting(this.containerEl)
@@ -473,6 +454,20 @@ export class TemplaterSettingTab extends PluginSettingTab {
                 s.infoEl.remove();
             }
         );
+
+        new Setting(this.containerEl).addButton((button: ButtonComponent) => {
+            button.setButtonText("Add new folder template")
+                .setTooltip("Add additional folder template")
+                .setCta()
+                .onClick(() => {
+                    this.plugin.settings.folder_templates.push({
+                        folder: "",
+                        template: "",
+                    });
+                    this.plugin.save_settings();
+                    this.display();
+                });
+        });
     }
 
     add_startup_templates_setting(): void {

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -58,10 +58,10 @@ export class TemplaterSettingTab extends PluginSettingTab {
         this.add_syntax_highlighting_settings();
         this.add_auto_jump_to_cursor();
         this.add_trigger_on_new_file_creation_setting();
-        this.add_templates_hotkeys_setting();
         if (this.plugin.settings.trigger_on_file_creation) {
             this.add_folder_templates_setting();
         }
+        this.add_templates_hotkeys_setting();
         this.add_startup_templates_setting();
         this.add_user_script_functions_setting();
         this.add_user_system_command_functions_setting();

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -324,7 +324,6 @@ export class TemplaterSettingTab extends PluginSettingTab {
     }
 
     add_folder_templates_setting(): void {
-        this.containerEl.createEl("h2", { text: "Folder templates" });
         new Setting(this.containerEl).setName("Folder templates").setHeading();
 
         const descHeading = document.createDocumentFragment();


### PR DESCRIPTION
Small quality of life issues related to folder templates:

1. Change the "+" button to be the same as the other "Add" buttons on the page (resolves #1428).
2. There were two headers being created for the "Folder templates" section; remove the duplicate.
3. The folder templates section is only visible if templates can be triggered on file create, but the toggle is further up in the settings. Move the Folder Templates section to be directly underneath the toggle so the user can easily see what changed.