### PR TITLE
Fix insert command removal

### DIFF
--- a/src/handlers/CommandHandler.ts
+++ b/src/handlers/CommandHandler.ts
@@ -129,7 +129,7 @@ export class CommandHandler {
                 `${this.plugin.manifest.id}:create-${template}`
             );
             app.commands.removeCommand(
-                `${this.plugin.manifest.id}:insert-${template}`
+                `${this.plugin.manifest.id}:${template}`
             );
         }
     }


### PR DESCRIPTION
Fixed bug where "insert" commands were added without a prefix, but removed with a prefix (see #1480; resolves #1481).