### PR TITLE
Issue/1497 fix mising character on open template modal

### DIFF
--- a/src/handlers/FuzzySuggester.ts
+++ b/src/handlers/FuzzySuggester.ts
@@ -44,8 +44,11 @@ export class FuzzySuggester extends FuzzySuggestModal<TFile> {
             item.path.startsWith(this.plugin.settings.templates_folder) &&
             normalizePath(this.plugin.settings.templates_folder) != "/"
         ) {
+            // Modify splice position if folder has a trailing slash
+            const folderLength = this.plugin.settings.templates_folder.length
+            const position = this.plugin.settings.templates_folder.endsWith('/') ? folderLength : folderLength + 1
             relativePath = item.path.slice(
-                this.plugin.settings.templates_folder.length + 1
+                position
             );
         }
         return relativePath.split(".").slice(0, -1).join(".");

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -87,6 +87,10 @@ export class TemplaterSettingTab extends PluginSettingTab {
                 cb.setPlaceholder("Example: folder1/folder2")
                     .setValue(this.plugin.settings.templates_folder)
                     .onChange((new_folder) => {
+                        // Trim folder and Strip ending slash if there
+                        new_folder = new_folder.trim()
+                        new_folder = new_folder.replace(/\/$/, "");
+
                         this.plugin.settings.templates_folder = new_folder;
                         this.plugin.save_settings();
                     });


### PR DESCRIPTION
- Trim and remove trailing forward slash on setting saving
- Modify the relative path slice if there is a trailing slash

This resolved #1497 