### PR TITLE
Feature/add user script descriptions

### DIFF
--- a/docs/documentation.toml
+++ b/docs/documentation.toml
@@ -2,6 +2,9 @@
 name = "app"
 description = "This module exposes the app instance. Prefer to use this over the global app instance."
 
+[tp.user]
+name = "user"
+description = "This module exposes custom made scripts, written by yourself within the script file folder location"
 
 [tp.config]
 name = "config"

--- a/docs/src/user-functions/script-user-functions.md
+++ b/docs/src/user-functions/script-user-functions.md
@@ -43,3 +43,22 @@ However, you can't access the template engine scoped variables like `tp` or `tR`
 You can pass as many arguments as you want to your function, depending on how you defined it.
 
 You can for example pass the `tp` object to your function, to be able to use all of the [internal variables / functions](../internal-variables-functions/overview.md) of Templater: `<% tp.user.<user_function_name>(tp) %>`
+
+## User Script Documentation
+
+Optionally you can document what a script does using the [TSDoc Standard](https://tsdoc.org/pages/spec/overview/) at the **top** of your method file. If provided, this will provide an intellisense-like experience for your user scripts similar to the experience of the other templater functions.
+
+Note: Currently, only **function summaries** are supported.
+
+### Example of User Script with Documentation
+
+```javascript
+/**
+ * This does something cool
+ */
+function doSomething() {
+    console.log('Something was done')
+}
+
+module.exports = doSomething;
+```

--- a/docs/src/user-functions/script-user-functions.md
+++ b/docs/src/user-functions/script-user-functions.md
@@ -46,7 +46,7 @@ You can for example pass the `tp` object to your function, to be able to use all
 
 ## User Script Documentation
 
-Optionally you can document what a script does using the [TSDoc Standard](https://tsdoc.org/pages/spec/overview/) at the **top** of your method file. If provided, this will provide an intellisense-like experience for your user scripts similar to the experience of the other templater functions.
+Optionally you can document what a script does using the [TSDoc Standard](https://tsdoc.org/) at the **top** of your method file. If provided, this will provide an intellisense-like experience for your user scripts similar to the experience of the other templater functions.
 
 Note: Currently, only **function summaries** are supported.
 

--- a/docs/src/user-functions/script-user-functions.md
+++ b/docs/src/user-functions/script-user-functions.md
@@ -48,8 +48,6 @@ You can for example pass the `tp` object to your function, to be able to use all
 
 Optionally you can document what a script does using the [TSDoc Standard](https://tsdoc.org/) at the **top** of your method file. If provided, this will provide an intellisense-like experience for your user scripts similar to the experience of the other templater functions.
 
-Note: Currently, only **function summaries** are supported.
-
 ### Example of User Script with Documentation
 
 ```javascript

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
         "@popperjs/core": "^2.11.6",
         "@silentvoid13/rusty_engine": "^0.4.0",
         "child_process": "^1.0.2",
-        "doctrine": "^3.0.0",
         "typescript": "^4.8.4"
     },
     "config": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "@codemirror/language": "github:lishid/cm-language",
         "@codemirror/state": "^6.1.2",
         "@codemirror/view": "^6.4.1",
+        "@microsoft/tsdoc": "^0.15.1",
         "@popperjs/core": "^2.11.6",
         "@silentvoid13/rusty_engine": "^0.4.0",
         "child_process": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
         "@popperjs/core": "^2.11.6",
         "@silentvoid13/rusty_engine": "^0.4.0",
         "child_process": "^1.0.2",
+        "doctrine": "^3.0.0",
         "typescript": "^4.8.4"
     },
     "config": {

--- a/src/editor/Autocomplete.ts
+++ b/src/editor/Autocomplete.ts
@@ -72,10 +72,10 @@ export class Autocomplete extends EditorSuggest<TpSuggestDocumentation> {
         return trigger_info;
     }
 
-    getSuggestions(context: EditorSuggestContext): TpSuggestDocumentation[] {
+    async getSuggestions(context: EditorSuggestContext): Promise<TpSuggestDocumentation[]> {
         let suggestions: Array<TpSuggestDocumentation>;
         if (this.module_name && this.function_trigger) {
-            suggestions = this.documentation.get_all_functions_documentation(
+            suggestions = await this.documentation.get_all_functions_documentation(
                 this.module_name as ModuleName,
                 this.function_name
             ) as TpFunctionDocumentation[];

--- a/src/editor/Autocomplete.ts
+++ b/src/editor/Autocomplete.ts
@@ -92,7 +92,23 @@ export class Autocomplete extends EditorSuggest<TpSuggestDocumentation> {
 
     renderSuggestion(value: TpSuggestDocumentation, el: HTMLElement): void {
         el.createEl("b", { text: value.name });
-        el.createEl("br");
+        if (is_function_documentation(value))
+        {
+            if (value.args &&
+                this.getNumberOfArguments(value.args) > 0
+            ) {
+                el.createEl('p', {text: "Parameter List:"})
+                const list = el.createEl("ol");
+                for (const [key, val] of Object.entries(value.args)) {
+                    const li = list.createEl("li");
+                    li.innerHTML = `<b>${key}: </b>${val.description}`
+                }
+            }
+            if (value.returns) {
+                const returnEl = el.createEl("p")
+                returnEl.innerHTML = `<b>Returns</b>: ${value.returns}`;
+            }
+        }
         if (this.function_trigger && is_function_documentation(value)) {
             el.createEl("code", { text: value.definition });
         }
@@ -124,6 +140,16 @@ export class Autocomplete extends EditorSuggest<TpSuggestDocumentation> {
             const cursor_pos = this.latest_trigger_info.end;
             cursor_pos.ch += value.queryKey.length;
             active_editor.editor.setCursor(cursor_pos);
+        }
+    }
+
+    getNumberOfArguments(
+        args: object
+    ): number {
+        try {
+            return new Map(Object.entries(args)).size;
+        } catch (error) {
+            return 0;
         }
     }
 }

--- a/src/editor/Autocomplete.ts
+++ b/src/editor/Autocomplete.ts
@@ -97,7 +97,7 @@ export class Autocomplete extends EditorSuggest<TpSuggestDocumentation> {
             if (value.args &&
                 this.getNumberOfArguments(value.args) > 0
             ) {
-                el.createEl('p', {text: "Parameter List:"})
+                el.createEl('p', {text: "Parameter list:"})
                 const list = el.createEl("ol");
                 for (const [key, val] of Object.entries(value.args)) {
                     const li = list.createEl("li");

--- a/src/editor/Autocomplete.ts
+++ b/src/editor/Autocomplete.ts
@@ -16,6 +16,7 @@ import {
     TpSuggestDocumentation,
 } from "./TpDocumentation";
 import TemplaterPlugin from "main";
+import { append_bolded_label_with_value_to_parent } from "utils/Utils";
 
 export class Autocomplete extends EditorSuggest<TpSuggestDocumentation> {
     //private in_command = false;
@@ -100,13 +101,11 @@ export class Autocomplete extends EditorSuggest<TpSuggestDocumentation> {
                 el.createEl('p', {text: "Parameter list:"})
                 const list = el.createEl("ol");
                 for (const [key, val] of Object.entries(value.args)) {
-                    const li = list.createEl("li");
-                    li.innerHTML = `<b>${key}: </b>${val.description}`
+                    append_bolded_label_with_value_to_parent(list, key, val.description)
                 }
             }
             if (value.returns) {
-                const returnEl = el.createEl("p")
-                returnEl.innerHTML = `<b>Returns</b>: ${value.returns}`;
+                append_bolded_label_with_value_to_parent(el, 'Returns', value.returns)
             }
         }
         if (this.function_trigger && is_function_documentation(value)) {

--- a/src/editor/TpDocumentation.ts
+++ b/src/editor/TpDocumentation.ts
@@ -1,5 +1,5 @@
 import TemplaterPlugin from "main";
-import { errorWrapperSync } from "utils/Error";
+import { errorWrapper } from "utils/Error";
 import { get_fn_params, get_tfiles_from_folder, is_object, populate_docs_from_user_scripts } from "utils/Utils";
 import documentation from "../../docs/documentation.toml";
 
@@ -106,7 +106,7 @@ export class Documentation {
                 !this.plugin.settings.user_scripts_folder
             )
                 return;
-            const files = await errorWrapperSync(
+            const files = await errorWrapper(
                 async () => {
                     const files = get_tfiles_from_folder(
                         this.plugin.app,

--- a/src/editor/TpDocumentation.ts
+++ b/src/editor/TpDocumentation.ts
@@ -72,7 +72,15 @@ export class Documentation {
     constructor(private plugin: TemplaterPlugin) {}
 
     get_all_modules_documentation(): TpModuleDocumentation[] {
-        return Object.values(this.documentation.tp).map((mod) => {
+        let tp = this.documentation.tp
+
+        // Remove 'user' if no user scripts found
+        if (!this.plugin.settings ||
+            !this.plugin.settings.user_scripts_folder) {
+            tp = Object.values(tp).filter((x) => x.name !== 'user')
+        }
+
+        return Object.values(tp).map((mod) => {
             mod.queryKey = mod.name;
             return mod;
         });

--- a/src/utils/TJDocFile.ts
+++ b/src/utils/TJDocFile.ts
@@ -2,9 +2,20 @@ import { TFile } from 'obsidian'
 
 export class TJDocFile extends TFile {
     public description: string
+    public returns: string
+    public arguments: TJDocFileArgument[]
 
     constructor(file: TFile) {
         super(file.vault, file.path)
         Object.assign(this, file)
+    }
+}
+
+export class TJDocFileArgument {
+    public name: string
+    public description: string
+    constructor(name: string, desc: string) {
+        this.name = name;
+        this.description = desc;
     }
 }

--- a/src/utils/TJDocFile.ts
+++ b/src/utils/TJDocFile.ts
@@ -2,19 +2,9 @@ import { TFile } from 'obsidian'
 
 export class TJDocFile extends TFile {
     public description: string
-    public arguments: TJDocFileArgument[]
 
     constructor(file: TFile) {
         super(file.vault, file.path)
         Object.assign(this, file)
-    }
-}
-
-export class TJDocFileArgument {
-    public name: string
-    public description: string
-    constructor(name: string, desc: string) {
-        this.name = name;
-        this.description = desc;
     }
 }

--- a/src/utils/TJDocFile.ts
+++ b/src/utils/TJDocFile.ts
@@ -1,0 +1,20 @@
+import { TFile } from 'obsidian'
+
+export class TJDocFile extends TFile {
+    public description: string
+    public arguments: TJDocFileArgument[]
+
+    constructor(file: TFile) {
+        super(file.vault, file.path)
+        Object.assign(this, file)
+    }
+}
+
+export class TJDocFileArgument {
+    public name: string
+    public description: string
+    constructor(name: string, desc: string) {
+        this.name = name;
+        this.description = desc;
+    }
+}

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -202,3 +202,27 @@ export function get_fn_params(func: (...args: unknown[]) => unknown) {
         .replace(/ /g, "")
         .split(",");
 }
+
+/**
+ * Use a parent HtmlElement to create a label with a value
+ * @param parent The parent HtmlElement; Use HtmlOListElement to return a `li` element
+ * @param title The title for the label which will be bolded
+ * @param value The value of the label
+ * @returns A label HtmlElement (p | li)
+ */
+export function append_bolded_label_with_value_to_parent(
+    parent: HTMLElement,
+     title: string,
+     value: string
+): HTMLElement{
+    const tag = parent instanceof HTMLOListElement ? "li" : "p";  
+
+    const para = parent.createEl(tag);
+    const bold = parent.createEl('b', {text: title});
+    para.appendChild(bold);
+    para.appendChild(document.createTextNode(`: ${value}`))
+
+    // Returns a p or li element
+    // Resulting in <b>Title</b>: value
+    return para;
+}

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -1,3 +1,7 @@
+const doctrine = require('doctrine')
+
+import { TJDocFile } from "./TJDocFile";
+
 import { TemplaterError } from "./Error";
 import {
     App,
@@ -70,6 +74,26 @@ export function get_tfiles_from_folder(
     });
 
     return files;
+}
+
+export async function populate_docs_from_user_scripts(
+    app: App,
+    files: Array<TFile>
+): Promise<TJDocFile[]> {
+    const docFiles = await Promise.all(files.map(async file => {
+            // Get file contents
+            const content = await app.vault.read(file)
+            if (!content.startsWith("/**")) return new TJDocFile(file);
+
+            const parsed = doctrine.parse(content,  {unwrap: true, sloppy: true})
+            const newDocFile = new TJDocFile(file);
+            newDocFile.description = parsed.description;
+
+            return newDocFile;
+        }
+    ));
+
+    return docFiles;
 }
 
 export function arraymove<T>(

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -82,7 +82,7 @@ export async function populate_docs_from_user_scripts(
 ): Promise<TJDocFile[]> {
     const docFiles = await Promise.all(files.map(async file => {
             // Get file contents
-            const content = await app.vault.read(file)
+            const content = await app.vault.cachedRead(file)
             
             const newDocFile = generate_jsdoc(file, content);
             


### PR DESCRIPTION
This is a feature I've wanted in templater as something that would help me.

- Implemented a new feature that adds 'intellisense' like support for user scripts. This allows descriptions, arguments, and return descriptions
- Added `user` to the **tp** model to allow easier access to user scripts. This is conditional if _Templater_ detects user scripts
- Added quick documentation  for this feature

# Example of user 'intellisense'
<img width="565" alt="Screenshot 2025-02-08 at 1 35 54 AM" src="https://github.com/user-attachments/assets/23b2d679-f401-4837-8219-33f51efe7e36" />

# Example of user script (preserves normal look when nothing provided)
<img width="265" alt="Screenshot 2025-02-11 at 11 54 08 AM" src="https://github.com/user-attachments/assets/cc9eef56-0055-403d-ad9e-2473de324138" />


# Example of user script 'intellisense' with description provided
<img width="322" alt="Screenshot 2025-02-08 at 1 36 50 AM" src="https://github.com/user-attachments/assets/386259c6-b5a0-4e6c-a4ba-b95e636b4ee5" />

# Example of user script with return and arguments
<img width="468" alt="Screenshot 2025-02-11 at 11 50 32 AM" src="https://github.com/user-attachments/assets/dc0884fe-8d8d-46cb-8517-3841b8947005" />
 'intellisense'



