### PR TITLE
Feature/intellisense render settings

### DIFF
--- a/src/editor/Autocomplete.ts
+++ b/src/editor/Autocomplete.ts
@@ -165,4 +165,8 @@ export class Autocomplete extends EditorSuggest<TpSuggestDocumentation> {
             return 0;
         }
     }
+
+    updateAutocompleteIntellisenseSetting(value: IntellisenseRenderOption){
+        this.intellisense_render_setting = value;
+    }
 }

--- a/src/editor/Autocomplete.ts
+++ b/src/editor/Autocomplete.ts
@@ -15,6 +15,14 @@ import {
     TpFunctionDocumentation,
     TpSuggestDocumentation,
 } from "./TpDocumentation";
+
+import {
+    IntellisenseRenderOption,
+    shouldRenderDescription,
+    shouldRenderParameters,
+    shouldRenderReturns
+} from "../settings/RenderSettings/IntellisenseRenderOption"
+
 import TemplaterPlugin from "main";
 import { append_bolded_label_with_value_to_parent } from "utils/Utils";
 
@@ -28,10 +36,12 @@ export class Autocomplete extends EditorSuggest<TpSuggestDocumentation> {
     private module_name: ModuleName | string;
     private function_trigger: boolean;
     private function_name: string;
+    private intellisense_render_setting: IntellisenseRenderOption
 
     constructor(plugin: TemplaterPlugin) {
         super(plugin.app);
         this.documentation = new Documentation(plugin);
+        this.intellisense_render_setting = plugin.settings.intellisense_render
     }
 
     onTrigger(
@@ -96,7 +106,8 @@ export class Autocomplete extends EditorSuggest<TpSuggestDocumentation> {
         if (is_function_documentation(value))
         {
             if (value.args &&
-                this.getNumberOfArguments(value.args) > 0
+                this.getNumberOfArguments(value.args) > 0 &&
+                shouldRenderParameters(this.intellisense_render_setting)
             ) {
                 el.createEl('p', {text: "Parameter list:"})
                 const list = el.createEl("ol");
@@ -104,14 +115,17 @@ export class Autocomplete extends EditorSuggest<TpSuggestDocumentation> {
                     append_bolded_label_with_value_to_parent(list, key, val.description)
                 }
             }
-            if (value.returns) {
+            if (value.returns &&
+                shouldRenderReturns(this.intellisense_render_setting)
+            ) {
                 append_bolded_label_with_value_to_parent(el, 'Returns', value.returns)
             }
         }
         if (this.function_trigger && is_function_documentation(value)) {
             el.createEl("code", { text: value.definition });
         }
-        if (value.description) {
+        if (value.description
+            && shouldRenderDescription(this.intellisense_render_setting)) {
             el.createEl("div", { text: value.description });
         }
     }

--- a/src/editor/Editor.ts
+++ b/src/editor/Editor.ts
@@ -31,6 +31,8 @@ export class Editor {
     // Note that this is `undefined` until `setup` has run.
     private templaterLanguage: Extension | undefined;
 
+    private autocomplete: Autocomplete;
+
     public constructor(private plugin: TemplaterPlugin) {
         this.cursor_jumper = new CursorJumper(plugin.app);
         this.activeEditorExtensions = [];
@@ -49,7 +51,8 @@ export class Editor {
     }
 
     async setup(): Promise<void> {
-        this.plugin.registerEditorSuggest(new Autocomplete(this.plugin));
+        this.autocomplete = new Autocomplete(this.plugin);
+        this.plugin.registerEditorSuggest(this.autocomplete);
 
         // We define our overlay as a stand-alone extension and keep a reference
         // to it around. This lets us dynamically turn it on and off as needed.
@@ -235,5 +238,9 @@ export class Editor {
                 templaterOverlay
             );
         });
+    }
+
+    updateEditorIntellisenseSetting(value: any){
+        this.autocomplete.updateAutocompleteIntellisenseSetting(value)
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -61,6 +61,7 @@ export default class TemplaterPlugin extends Plugin {
 
     async save_settings(): Promise<void> {
         await this.saveData(this.settings);
+        this.editor_handler.updateEditorIntellisenseSetting(this.settings.intellisense_render);
     }
 
     async load_settings(): Promise<void> {

--- a/src/settings/RenderSettings/IntellisenseRenderOption.ts
+++ b/src/settings/RenderSettings/IntellisenseRenderOption.ts
@@ -1,0 +1,52 @@
+/**
+ * The recongized render setting options
+ */
+export enum IntellisenseRenderOption {
+    Off = 0,
+    RenderDescriptionParameterReturn = 1,
+    RenderDescriptionParameterList = 2,
+    RenderDescriptionReturn = 3,
+    RenderDescriptionOnly = 4
+}
+
+/**
+ * 
+ * @param value The intellisense render setting
+ * @returns True if the Return Intellisense should render, otherwise false
+ */
+export function shouldRenderReturns(render_setting: IntellisenseRenderOption | boolean) : boolean {
+    // Render override
+    if (isBoolean(render_setting)) return render_setting
+
+    return [
+        IntellisenseRenderOption.RenderDescriptionParameterReturn,
+        IntellisenseRenderOption.RenderDescriptionReturn
+    ].includes(render_setting)
+}
+
+/**
+ * 
+ * @param value The intellisense render setting
+ * @returns True if the Parameters Intellisense should render, otherwise false
+ */
+export function shouldRenderParameters(render_setting: IntellisenseRenderOption) : boolean {
+    // Render override
+    if (isBoolean(render_setting)) return render_setting
+
+    return [
+        IntellisenseRenderOption.RenderDescriptionParameterReturn,
+        IntellisenseRenderOption.RenderDescriptionParameterList
+    ].includes(render_setting);
+}
+
+/**
+ * 
+ * @param value The intellisense render setting
+ * @returns True if the Description Intellisense should render, otherwise false
+ */
+export function shouldRenderDescription(render_setting: IntellisenseRenderOption) : boolean {
+    // Render override
+    if (isBoolean(render_setting)) return render_setting
+
+    return render_setting != IntellisenseRenderOption.Off
+}

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -5,6 +5,7 @@ import { log_error } from "utils/Log";
 import { arraymove, get_tfiles_from_folder } from "utils/Utils";
 import { FileSuggest, FileSuggestMode } from "./suggesters/FileSuggester";
 import { FolderSuggest } from "./suggesters/FolderSuggester";
+import { IntellisenseRenderOption } from "./RenderSettings/IntellisenseRenderOption"
 
 export interface FolderTemplate {
     folder: string;
@@ -33,6 +34,7 @@ export const DEFAULT_SETTINGS: Settings = {
     syntax_highlighting_mobile: false,
     enabled_templates_hotkeys: [""],
     startup_templates: [""],
+    intellisense_render: IntellisenseRenderOption.RenderDescriptionParameterReturn
 };
 
 export interface Settings {
@@ -52,6 +54,7 @@ export interface Settings {
     syntax_highlighting_mobile: boolean;
     enabled_templates_hotkeys: Array<string>;
     startup_templates: Array<string>;
+    intellisense_render: number;
 }
 
 export class TemplaterSettingTab extends PluginSettingTab {
@@ -731,6 +734,23 @@ export class TemplaterSettingTab extends PluginSettingTab {
                 // @ts-ignore
                 cb.containerEl.addClass("templater_search");
             });
+
+        new Setting(this.containerEl)
+        .setName('User script intellisense')
+        .setDesc('Determine how you\'d like to have user script intellisense render. Note values will not render if not in the script.')
+        .addDropdown(cb => {
+            cb
+                .addOption("0", "Turn off intellisense")
+                .addOption("1", "Render method description, parameters list, and return")
+                .addOption("2", "Render method description and parameters list")
+                .addOption("3", "Render method description and return")
+                .addOption("4", "Render method description")
+                .setValue(this.plugin.settings.intellisense_render.toString())
+                .onChange((value) => {
+                    this.plugin.settings.intellisense_render = parseInt(value);
+                    this.plugin.save_settings();
+                })
+        })
 
         desc = document.createDocumentFragment();
         let name: string;


### PR DESCRIPTION
This adds a feature to allow render settings for intellisense which was added in #1539 
I thought it could be beneficial to alter the render despite what is provided in the user script file

This adds a new setting
 
<img width="780" alt="Screenshot 2025-03-06 at 11 01 48 PM" src="https://github.com/user-attachments/assets/fac04bc3-21ed-4a61-ada9-523089c3faa4" />

This allows the user to change the render from the DEFAULT of full to various options including off.

This allows the user to render what they want instead of having to alter the source code of the user script which they might not want to do

## Off
<img width="299" alt="Screenshot 2025-03-06 at 11 09 11 PM" src="https://github.com/user-attachments/assets/ceee1eae-1723-4798-abef-e36272ae0cab" />

## Full Render
<img width="481" alt="Screenshot 2025-03-06 at 11 09 22 PM" src="https://github.com/user-attachments/assets/952d184f-9ea9-44c0-820a-a86ae257ea89" />

## Description and Parameter List
<img width="418" alt="Screenshot 2025-03-06 at 11 09 33 PM" src="https://github.com/user-attachments/assets/eb42b45b-d5ef-46a3-a8f7-f0045bc3ea42" />

## Description and Return
<img width="461" alt="Screenshot 2025-03-06 at 11 09 43 PM" src="https://github.com/user-attachments/assets/3a9b2e2f-db8d-4872-81fa-08952c5d3711" />

## Description Only
<img width="311" alt="Screenshot 2025-03-06 at 11 09 52 PM" src="https://github.com/user-attachments/assets/fd97b500-b774-47eb-b55c-f0c4b19df3d7" />