### PR TITLE
Reload plugin settings when data.json modified externally

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -54,6 +54,11 @@ export default class TemplaterPlugin extends Plugin {
         });
     }
 
+    async onExternalSettingsChange() {
+        await this.load_settings();
+        console.log("data.json modified externally, reloading plugin settings");
+    }
+
     onunload(): void {
         // Failsafe in case teardown doesn't happen immediately after template execution
         this.templater.functions_generator.teardown();


### PR DESCRIPTION
I have a workflow that modifies the templater settings programmatically. Currently, I am forced to manually reload obsidian to have templater re-parse its `data.json` file to pick up the changes made by my program. This isn't ideal.

This small PR makes it so this step is automated - when Obsidian says the plugin's `data.json` file has been modified, the plugin reacts by loading the settings from the file the same way it does on startup.

## Related

Closes #1564 