### PR TITLE
Cleaner display of custom hot key in command palette

### DIFF
--- a/src/handlers/CommandHandler.ts
+++ b/src/handlers/CommandHandler.ts
@@ -93,7 +93,7 @@ export class CommandHandler {
         if (new_template) {
             this.plugin.addCommand({
                 id: new_template,
-                name: `Insert ${new_template}`,
+                name: `Insert ${new_template.split(/\/|\./).slice(-2,-1)}`,
                 icon: "templater-icon",
                 callback: () => {
                     const template = errorWrapperSync(
@@ -110,7 +110,7 @@ export class CommandHandler {
             });
             this.plugin.addCommand({
                 id: `create-${new_template}`,
-                name: `Create ${new_template}`,
+                name: `Create ${new_template.split(/\/|\./).slice(-2,-1)}`,
                 icon: "templater-icon",
                 callback: () => {
                     const template = errorWrapperSync(

--- a/src/handlers/CommandHandler.ts
+++ b/src/handlers/CommandHandler.ts
@@ -2,6 +2,7 @@ import TemplaterPlugin from "main";
 import { Platform } from "obsidian";
 import { errorWrapperSync } from "utils/Error";
 import { resolve_tfile } from "utils/Utils";
+import { Settings } from "settings/Settings";
 
 export class CommandHandler {
     constructor(private plugin: TemplaterPlugin) {}
@@ -93,7 +94,7 @@ export class CommandHandler {
         if (new_template) {
             this.plugin.addCommand({
                 id: new_template,
-                name: `Insert ${new_template.split(/\/|\./).slice(-2,-1)}`,
+                name: `Insert ${new_template.slice(Settings.templates_folder.length,-3)}`,
                 icon: "templater-icon",
                 callback: () => {
                     const template = errorWrapperSync(
@@ -110,7 +111,7 @@ export class CommandHandler {
             });
             this.plugin.addCommand({
                 id: `create-${new_template}`,
-                name: `Create ${new_template.split(/\/|\./).slice(-2,-1)}`,
+                name: `Create ${new_template.slice(Settings.templates_folder.length,-3)}`,
                 icon: "templater-icon",
                 callback: () => {
                     const template = errorWrapperSync(

--- a/src/handlers/CommandHandler.ts
+++ b/src/handlers/CommandHandler.ts
@@ -2,7 +2,6 @@ import TemplaterPlugin from "main";
 import { Platform } from "obsidian";
 import { errorWrapperSync } from "utils/Error";
 import { resolve_tfile } from "utils/Utils";
-import { Settings } from "settings/Settings";
 
 export class CommandHandler {
     constructor(private plugin: TemplaterPlugin) {}
@@ -92,9 +91,13 @@ export class CommandHandler {
         this.remove_template_hotkey(old_template);
 
         if (new_template) {
+            const new_template_name = new_template.slice(
+                this.plugin.settings.templates_folder.length + 1,
+                -3
+            );
             this.plugin.addCommand({
-                id: new_template,
-                name: `Insert ${new_template.slice(Settings.templates_folder.length,-3)}`,
+                id: new_template_name,
+                name: `Insert ${new_template_name}`,
                 icon: "templater-icon",
                 callback: () => {
                     const template = errorWrapperSync(
@@ -110,8 +113,8 @@ export class CommandHandler {
                 },
             });
             this.plugin.addCommand({
-                id: `create-${new_template}`,
-                name: `Create ${new_template.slice(Settings.templates_folder.length,-3)}`,
+                id: `create-${new_template_name}`,
+                name: `Create ${new_template_name}`,
                 icon: "templater-icon",
                 callback: () => {
                     const template = errorWrapperSync(

--- a/src/handlers/CommandHandler.ts
+++ b/src/handlers/CommandHandler.ts
@@ -96,7 +96,7 @@ export class CommandHandler {
                 -3
             );
             this.plugin.addCommand({
-                id: new_template_name,
+                id: new_template,
                 name: `Insert ${new_template_name}`,
                 icon: "templater-icon",
                 callback: () => {
@@ -113,7 +113,7 @@ export class CommandHandler {
                 },
             });
             this.plugin.addCommand({
-                id: `create-${new_template_name}`,
+                id: `create-${new_template}`,
                 name: `Create ${new_template_name}`,
                 icon: "templater-icon",
                 callback: () => {


### PR DESCRIPTION
The name of a custom command, which inserts or creates a template, shows now the title of the template instead of its path, which improves readability in the command palette.