### PR TITLE
Fix tp.file.create_new() does not return to original context

### DIFF
--- a/src/core/Templater.ts
+++ b/src/core/Templater.ts
@@ -74,6 +74,10 @@ export class Templater {
         };
     }
 
+    get_current_running_config(): RunningConfig {
+        return this.functions_generator.get_config();
+    }
+
     async read_and_parse_template(config: RunningConfig): Promise<string> {
         const template_content = await this.plugin.app.vault.read(
             config.template_file as TFile
@@ -164,6 +168,8 @@ export class Templater {
             return;
         }
 
+        const backup_config = this.get_current_running_config();
+
         const { path } = created_note;
         this.start_templater_task(path);
         let running_config: RunningConfig;
@@ -223,6 +229,10 @@ export class Templater {
             });
         }
 
+        await this.functions_generator.generate_object(
+            backup_config,
+            FunctionsMode.USER_INTERNAL
+        );
         await this.end_templater_task(path);
         return created_note;
     }

--- a/src/core/functions/FunctionsGenerator.ts
+++ b/src/core/functions/FunctionsGenerator.ts
@@ -19,6 +19,10 @@ export class FunctionsGenerator implements IGenerateObject {
         this.user_functions = new UserFunctions(this.plugin);
     }
 
+    get_config(): RunningConfig {
+        return this.internal_functions.get_config();
+    }
+
     async init(): Promise<void> {
         await this.internal_functions.init();
     }

--- a/src/core/functions/internal_functions/InternalFunctions.ts
+++ b/src/core/functions/internal_functions/InternalFunctions.ts
@@ -23,6 +23,10 @@ export class InternalFunctions implements IGenerateObject {
         this.modules_array.push(new InternalModuleConfig(this.plugin));
     }
 
+    get_config(): RunningConfig {
+        return this.modules_array[0].get_config();
+    }
+
     async init(): Promise<void> {
         for (const mod of this.modules_array) {
             await mod.init();

--- a/src/core/functions/internal_functions/InternalModule.ts
+++ b/src/core/functions/internal_functions/InternalModule.ts
@@ -16,6 +16,10 @@ export abstract class InternalModule implements IGenerateObject {
         return this.name;
     }
 
+    get_config(): RunningConfig {
+        return this.config;
+    }
+
     abstract create_static_templates(): Promise<void>;
     abstract create_dynamic_templates(): Promise<void>;
     abstract teardown(): Promise<void>;


### PR DESCRIPTION
I added functionality to create a backup of the current config before switching to a new one when creating a new file with ``create_new_note_from_template`` and reload it after the new file is created. 

This fixes #1554 

I tested it with an extended example from the bug
```
<%*
console.log('This message was before')
await tp.file.create_new("MyFileContent", "MyFilename", false, tp.file.folder(true))

console.log(`I'm on Original: ${tp.file.path(true)}`)
%>
```
File get's created and console prints as expected.

With current master: 
<img width="687" height="46" alt="image" src="https://github.com/user-attachments/assets/e8f0cb3f-7aeb-4d22-bca1-3f39ba4393fd" />

With my changes:
<img width="932" height="60" alt="image" src="https://github.com/user-attachments/assets/42f4391a-e4ab-4937-ae9f-c200a225aa5c" />

