### PR TITLE
Fixed template name when templates folder is not configured

### DIFF
--- a/src/handlers/CommandHandler.ts
+++ b/src/handlers/CommandHandler.ts
@@ -91,10 +91,16 @@ export class CommandHandler {
         this.remove_template_hotkey(old_template);
 
         if (new_template) {
+            // Determine started index based on templates folder
+            const template_start_index = this.plugin.settings.templates_folder ?
+                this.plugin.settings.templates_folder.length + 1 :
+                0;
+
             const new_template_name = new_template.slice(
-                this.plugin.settings.templates_folder.length + 1,
+                template_start_index,
                 -3
             );
+
             this.plugin.addCommand({
                 id: new_template,
                 name: `Insert ${new_template_name}`,


### PR DESCRIPTION
Fixes #1664 

This conditionally selects the starting index for the template name based on if a template folder is configured