### PR TITLE
Handle unset templates directory

### DIFF
--- a/src/handlers/FuzzySuggester.ts
+++ b/src/handlers/FuzzySuggester.ts
@@ -46,7 +46,14 @@ export class FuzzySuggester extends FuzzySuggestModal<TFile> {
         ) {
             // Modify splice position if folder has a trailing slash
             const folderLength = this.plugin.settings.templates_folder.length
-            const position = this.plugin.settings.templates_folder.endsWith('/') ? folderLength : folderLength + 1
+            let position: number;
+            if (folderLength === 0) {
+                position = 0;
+            } else if (this.plugin.settings.templates_folder.endsWith("/")) {
+                position = folderLength;
+            } else {
+                position = folderLength + 1;
+            }
             relativePath = item.path.slice(
                 position
             );


### PR DESCRIPTION
If `Template folder location` is not set, path names of scripts are displayed incorrectly. This only affects the display, they still run correctly.

<img width="361" height="165" alt="image" src="https://github.com/user-attachments/assets/88eff339-cf78-4095-b29f-c052a00910dc" />

Added a check for `folderLength === 0`.

I've tested locally and it works. No lint errors introduced.