### PR TITLE
feat: add CLI handler for template-based note creation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
     "name": "Templater",
     "version": "2.18.1",
     "description": "Create and use templates",
-    "minAppVersion": "1.5.0",
+    "minAppVersion": "1.12.2",
     "author": "SilentVoid",
     "authorUrl": "https://github.com/SilentVoid13",
     "helpUrl": "https://silentvoid13.github.io/Templater/",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "esbuild-plugin-toml": "^0.0.1",
         "eslint": "^8.27.0",
         "moment": "^2.29.4",
-        "obsidian": "^1.11.4",
+        "obsidian": "^1.12.2",
         "standard-version": "^9.5.0",
         "stringify-package": "^1.0.1",
         "ts-node": "^9.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,8 +79,8 @@ importers:
         specifier: ^2.29.4
         version: 2.30.1
       obsidian:
-        specifier: ^1.11.4
-        version: 1.11.4(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+        specifier: ^1.12.2
+        version: 1.12.3(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
       standard-version:
         specifier: ^9.5.0
         version: 9.5.0
@@ -1258,8 +1258,8 @@ packages:
     resolution: {integrity: sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==}
     engines: {node: '>=10'}
 
-  obsidian@1.11.4:
-    resolution: {integrity: sha512-n0KD3S+VndgaByrEtEe8NELy0ya6/s+KZ7OcxA6xOm5NN4thxKpQjo6eqEudHEvfGCeT/TYToAKJzitQ1I3XTg==}
+  obsidian@1.12.3:
+    resolution: {integrity: sha512-HxWqe763dOqzXjnNiHmAJTRERN8KILBSqxDSEqbeSr7W8R8Jxezzbca+nz1LiiqXnMpM8lV2jzAezw3CZ4xNUw==}
     peerDependencies:
       '@codemirror/state': 6.5.0
       '@codemirror/view': 6.38.6
@@ -3034,7 +3034,7 @@ snapshots:
       semver: 7.5.4
       validate-npm-package-license: 3.0.4
 
-  obsidian@1.11.4(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
+  obsidian@1.12.3(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
     dependencies:
       '@codemirror/state': 6.4.0
       '@codemirror/view': 6.23.1

--- a/src/handlers/CommandHandler.ts
+++ b/src/handlers/CommandHandler.ts
@@ -1,7 +1,7 @@
 import TemplaterPlugin from "main";
-import { Platform } from "obsidian";
+import { normalizePath, Platform, TFile, TFolder } from "obsidian";
 import { errorWrapperSync } from "utils/Error";
-import { resolve_tfile } from "utils/Utils";
+import { resolve_tfile, resolve_tfolder, get_folder_path_from_file_path } from "utils/Utils";
 
 export class CommandHandler {
     constructor(private plugin: TemplaterPlugin) {}
@@ -74,6 +74,7 @@ export class CommandHandler {
         });
 
         this.register_templates_hotkeys();
+        this.register_cli_handler();
     }
 
     register_templates_hotkeys(): void {
@@ -142,6 +143,93 @@ export class CommandHandler {
         if (template) {
             this.plugin.removeCommand(`${template}`);
             this.plugin.removeCommand(`create-${template}`);
+        }
+    }
+
+    register_cli_handler(): void {
+        this.plugin.registerCliHandler(
+            "templater:create-from-template",
+            "Create a new note from a Templater template",
+            {
+                template: {
+                    value: "<path>",
+                    description: "Template file path (relative to vault root or templates folder)",
+                    required: true,
+                },
+                file: {
+                    value: "<path>",
+                    description: "Output file path (relative to vault root)",
+                    required: true,
+                },
+                open: {
+                    description: "Open the created file in the UI",
+                    required: false,
+                },
+            },
+            async (params) => this.handle_create_from_template(params)
+        );
+    }
+
+    private resolve_template_file(template: string): TFile {
+        let template_path = template;
+        if (!template_path.endsWith(".md")) {
+            template_path = `${template_path}.md`;
+        }
+
+        try {
+            return resolve_tfile(this.plugin.app, template_path);
+        } catch {
+            const templates_folder = this.plugin.settings.templates_folder;
+            if (templates_folder) {
+                const full_path = normalizePath(`${templates_folder}/${template_path}`);
+                return resolve_tfile(this.plugin.app, full_path);
+            }
+            throw new Error(`Template "${template}" not found`);
+        }
+    }
+
+    private async handle_create_from_template(
+        params: Record<string, string | "true">
+    ): Promise<string> {
+        const { template, file, open } = params;
+
+        if (!template) {
+            return "Error: template parameter is required";
+        }
+        if (!file) {
+            return "Error: file parameter is required";
+        }
+
+        try {
+            const template_file = this.resolve_template_file(template);
+
+            const file_path = normalizePath(file);
+            const folder_path = get_folder_path_from_file_path(file_path);
+            const filename = file_path.slice(folder_path.length + 1).replace(/\.md$/, "");
+
+            let folder: TFolder | undefined;
+            if (folder_path) {
+                try {
+                    folder = resolve_tfolder(this.plugin.app, folder_path);
+                } catch {
+                    // Folder will be created by create_new_note_from_template
+                }
+            }
+
+            const open_note = open === "true";
+            const created_file = await this.plugin.templater.create_new_note_from_template(
+                template_file,
+                folder ?? folder_path,
+                filename,
+                open_note
+            );
+
+            if (created_file) {
+                return created_file.path;
+            }
+            return "Error: Failed to create note from template";
+        } catch (error) {
+            return `Error: ${error instanceof Error ? error.message : String(error)}`;
         }
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,23 +1,4 @@
 declare module "obsidian" {
-    interface CliFlag {
-        value?: string;
-        description: string;
-        required?: boolean;
-    }
-
-    type CliFlags = Record<string, CliFlag>;
-    type CliData = Record<string, string | "true">;
-    type CliHandler = (params: CliData) => string | Promise<string>;
-
-    interface Plugin {
-        registerCliHandler(
-            command: string,
-            description: string,
-            flags: CliFlags | null,
-            handler: CliHandler
-        ): void;
-    }
-
     interface App {
         dom: {
             appContainerEl: HTMLElement;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,23 @@
 declare module "obsidian" {
+    interface CliFlag {
+        value?: string;
+        description: string;
+        required?: boolean;
+    }
+
+    type CliFlags = Record<string, CliFlag>;
+    type CliData = Record<string, string | "true">;
+    type CliHandler = (params: CliData) => string | Promise<string>;
+
+    interface Plugin {
+        registerCliHandler(
+            command: string,
+            description: string,
+            flags: CliFlags | null,
+            handler: CliHandler
+        ): void;
+    }
+
     interface App {
         dom: {
             appContainerEl: HTMLElement;

--- a/tests/CommandHandler.test.ts
+++ b/tests/CommandHandler.test.ts
@@ -1,0 +1,115 @@
+import { expect } from "chai";
+import TestTemplaterPlugin from "./main.test";
+
+export function CommandHandlerTests(t: TestTemplaterPlugin) {
+    t.test("create_new_note_from_template creates file with processed content", async () => {
+        const template = await t.createFile("TestTemplate.md", "# <% tp.file.title %>");
+
+        const created = await t.plugin.templater.create_new_note_from_template(
+            template,
+            undefined,
+            "CLITestNote",
+            false
+        );
+
+        expect(created).to.not.be.undefined;
+        expect(created).to.not.be.null;
+        expect(created?.name).to.equal("CLITestNote.md");
+
+        if (created) {
+            const content = await t.app.vault.read(created);
+            expect(content).to.equal("# CLITestNote");
+            t.active_files.push(created);
+        }
+    });
+
+    t.test("create_new_note_from_template auto-increments filename on conflict", async () => {
+        const template = await t.createFile("TestTemplate2.md", "Test content");
+
+        const first = await t.plugin.templater.create_new_note_from_template(
+            template,
+            undefined,
+            "ConflictTest",
+            false
+        );
+        if (first) {
+            t.active_files.push(first);
+        }
+
+        const second = await t.plugin.templater.create_new_note_from_template(
+            template,
+            undefined,
+            "ConflictTest",
+            false
+        );
+        if (second) {
+            t.active_files.push(second);
+        }
+
+        expect(first?.name).to.equal("ConflictTest.md");
+        expect(second?.name).to.equal("ConflictTest 1.md");
+    });
+
+    t.test("create_new_note_from_template creates file in folder", async () => {
+        const template = await t.createFile("TestTemplate3.md", "Folder test");
+        const folder = await t.createFolder("CLITestFolder");
+
+        const created = await t.plugin.templater.create_new_note_from_template(
+            template,
+            folder,
+            "FolderNote",
+            false
+        );
+
+        expect(created).to.not.be.undefined;
+        expect(created?.path).to.equal("CLITestFolder/FolderNote.md");
+
+        if (created) {
+            t.active_files.push(created);
+        }
+    });
+
+    t.test("create_new_note_from_template processes frontmatter", async () => {
+        const templateContent = `---
+title: "<% tp.file.title %>"
+---
+# <% tp.file.title %>`;
+        const template = await t.createFile("TestTemplate4.md", templateContent);
+
+        const created = await t.plugin.templater.create_new_note_from_template(
+            template,
+            undefined,
+            "FrontmatterTest",
+            false
+        );
+
+        expect(created).to.not.be.undefined;
+
+        if (created) {
+            const content = await t.app.vault.read(created);
+            expect(content).to.include('title: "FrontmatterTest"');
+            expect(content).to.include("# FrontmatterTest");
+            t.active_files.push(created);
+        }
+    });
+
+    t.test("create_new_note_from_template with string content", async () => {
+        const templateContent = "# <% tp.file.title %>\nCreated via string";
+
+        const created = await t.plugin.templater.create_new_note_from_template(
+            templateContent,
+            undefined,
+            "StringTest",
+            false
+        );
+
+        expect(created).to.not.be.undefined;
+        expect(created?.name).to.equal("StringTest.md");
+
+        if (created) {
+            const content = await t.app.vault.read(created);
+            expect(content).to.equal("# StringTest\nCreated via string");
+            t.active_files.push(created);
+        }
+    });
+}

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -18,6 +18,7 @@ import { InternalModuleHooksTests } from "./InternalTemplates/InternalModuleHook
 import { InternalModuleSystemTests } from "./InternalTemplates/InternalModuleSystem.test";
 import { InternalModuleConfigTests } from "./InternalTemplates/InternalModuleConfig.test";
 import { TemplaterTests } from "./Templater.test";
+import { CommandHandlerTests } from "./CommandHandler.test";
 
 chai.use(chaiAsPromised);
 
@@ -112,6 +113,7 @@ export default class TestTemplaterPlugin extends Plugin {
         InternalModuleSystemTests(this);
         InternalModuleConfigTests(this);
         TemplaterTests(this);
+        CommandHandlerTests(this);
     }
 
     test(name: string, fn: () => Promise<void>) {


### PR DESCRIPTION
## Summary
Fixes #1702 

- Adds `templater:create-from-template` CLI handler using Obsidian's `registerCliHandler` API (v1.12.2+)
- Enables silent, headless creation of templated notes via command line
- Resolves templates from configured templates folder or full vault path

## Usage

```bash
obsidian templater:create-from-template template="MyTemplate" file="Path/To/Note.md"
obsidian templater:create-from-template template="MyTemplate" file="Path/To/Note.md" open
```

| Parameter | Required | Description |
|-----------|----------|-------------|
| `template` | Yes | Template path (relative to vault or templates folder, `.md` optional) |
| `file` | Yes | Output file path (relative to vault root) |
| `open` | No | Opens the created file in the UI |

## Changes

- `src/handlers/CommandHandler.ts` - CLI handler registration and logic
- `src/types.ts` - TypeScript declarations for Obsidian CLI API
- `manifest.json` - Updated `minAppVersion` to `1.12.2`
- `package.json` - Updated `obsidian` dependency to `1.12.2`
- `tests/CommandHandler.test.ts` - Test suite

## Test plan

- [x] Build passes (`npm run build`)
- [x] Lint passes on new code
- [x] Test build compiles (`npm run test-build`)
- [x] All CLI handler tests pass in Obsidian
- [x] Manual CLI test with real template