### PR TITLE
fix: Docs Typo - syntax.md file: typo in the word 'simple' instead of

### DIFF
--- a/docs/src/syntax.md
+++ b/docs/src/syntax.md
@@ -34,7 +34,7 @@ All arguments must be passed in the correct order.
 
 The arguments of a function can have different **types**. Here is a non-exhaustive list of the possible types of a function:
 
-- A `string` type means the value must be placed within simple or double quotes (`"value"` or `'value'`)
+- A `string` type means the value must be placed within single or double quotes (`"value"` or `'value'`)
 - A `number` type means the value must be an integer (`15`, `-5`, ...)
 - A `boolean` type means the value must be either `true` or `false` (completely lower case), and nothing else.
 


### PR DESCRIPTION
Fixes #1704

Corrects a typo in `docs/src/syntax.md` where the word "simple" was used instead of "single" when describing string quote types. The error was a plain misspelling introduced in the documentation. Changes "simple or double quotes" to "single or double quotes" on line 37 of `docs/src/syntax.md`. Verified by reviewing the rendered markdown to confirm the corrected phrasing accurately describes single-quoted (`'value'`) and double-quoted (`"value"`) string syntax.