### PR TITLE
fix: call super.onOpen() in SuggesterModal to restore suggestions rendering

### DIFF
--- a/src/core/functions/internal_functions/system/SuggesterModal.ts
+++ b/src/core/functions/internal_functions/system/SuggesterModal.ts
@@ -24,6 +24,7 @@ export class SuggesterModal<T> extends FuzzySuggestModal<T> {
     }
 
     onOpen(): void {
+        super.onOpen();
         if (this.default_value !== undefined) {
             this.inputEl.value = this.getItemText(this.default_value);
             this.inputEl.dispatchEvent(new InputEvent("input"));


### PR DESCRIPTION
## Problem

Commit `063a8ac` introduced a `default_value` parameter for `tp.system.suggester` and added an `onOpen()` override to `SuggesterModal` to pre-populate the input. However, the override does not call `super.onOpen()`.

`FuzzySuggestModal` inherits `onOpen()` from `SuggestModal`, which is responsible for focusing the input element and calling `updateSuggestions()`. Without it, the modal opens but renders no suggestions — making `tp.system.suggester` completely non-functional in 2.19.1.

## Fix

Add `super.onOpen()` as the first call in the override:

```ts
onOpen(): void {
    super.onOpen(); // focuses input + populates suggestions
    if (this.default_value !== undefined) {
        this.inputEl.value = this.getItemText(this.default_value);
        this.inputEl.dispatchEvent(new InputEvent("input"));
    }
}
```

Calling `super.onOpen()` first ensures the base modal initializes correctly, then the default value is applied on top — which is also the correct order semantically.

## Impact

All users of `tp.system.suggester` are affected in 2.19.1. Downgrading to 2.19.0 is the current workaround.