### PR TITLE
docs: add missing closing %> tag in system-user-functions.md

### DIFF
--- a/docs/src/user-functions/system-user-functions.md
+++ b/docs/src/user-functions/system-user-functions.md
@@ -22,7 +22,7 @@ You can pass optional arguments to user functions. They must be passed as a sing
 
 These arguments will be made available for your programs / scripts in the form of [environment variables](https://en.wikipedia.org/wiki/Environment_variable).
 
-In our previous example, this would give the following command declaration: `<% tp.user.echo({a: "value 1", b: "value 2"})`. 
+In our previous example, this would give the following command declaration: `<% tp.user.echo({a: "value 1", b: "value 2"}) %>`. 
 
 If our system command was calling a bash script, we would be able to access variables `a` and `b` using `$a` and `$b`.
 


### PR DESCRIPTION
## Summary
Fixes #1614 — the code example on the "System Commands" documentation page was missing the closing `%>` tag.

## Change
`docs/src/user-functions/system-user-functions.md` line 25:
```
- `<% tp.user.echo({a: "value 1", b: "value 2"})`.
+ `<% tp.user.echo({a: "value 1", b: "value 2"}) %>`.
```

## Type of Change
- [x] Documentation (typo fix)