### PR TITLE
fix: resolve #1568 — "Create <path/to/template>" should be named "Create from <path/to/template>"

### DIFF
--- a/src/handlers/CommandHandler.ts
+++ b/src/handlers/CommandHandler.ts
@@ -129,7 +129,7 @@ export class CommandHandler {
             });
             this.plugin.addCommand({
                 id: `create-${new_template}`,
-                name: `Create ${new_template_name}`,
+                name: `Create from ${new_template_name}`,
                 icon: "templater-icon",
                 callback: async () => {
                     const template = errorWrapperSync(


### PR DESCRIPTION
## Summary

fix: resolve #1568 — "Create <path/to/template>" should be named "Create from <path/to/template>"

## Problem

**Severity**: `High` | **File**: `src/handlers/CommandHandler.ts`

The command "Create <path/to/template>" is misleading as it suggests creating a template rather than creating a file from a template. This change renames it to "Create from <path/to/template>" to better reflect its actual function.

## Solution

Find where the command is registered (likely using `this.app.commands.addCommand`) and change the name/id from "Create <path/to/template>" to "Create from <path/to/template>". Also update any related command callbacks or references to maintain consistency.

## Changes

- `src/handlers/CommandHandler.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced