### PR TITLE
fix: resolve #1344 — Too small input area for folders path in New Folder template

### DIFF
--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -107,6 +107,7 @@ export class TemplaterSettingTab extends PluginSettingTab {
                         await this.plugin.save_settings();
                     });
                 cb.containerEl.addClass("templater_search");
+                cb.inputEl.addClass("templater-folder-input");
             });
     }
 


### PR DESCRIPTION
## Summary

fix: resolve #1344 — Too small input area for folders path in New Folder template

## Problem

**Severity**: `Medium` | **File**: `src/settings/Settings.ts`

The current input area for folder paths in the "Add new folders template" section is too small on mobile devices, making it difficult to use in portrait mode. The input field needs to be made more responsive and potentially multiline or wrapped to accommodate longer folder paths on smaller screens.

## Solution



## Changes

- `src/settings/Settings.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced