### PR TITLE
fix: resolve #1674 — When reading is the default mode for new tabs and you create a new note from a Base configured create a file in a folder, the folder template does not fully trigger

### DIFF
--- a/src/handlers/FuzzySuggester.ts
+++ b/src/handlers/FuzzySuggester.ts
@@ -66,10 +66,18 @@ export class FuzzySuggester extends FuzzySuggestModal<TFile> {
                 void this.plugin.templater.append_template_to_active_file(item);
                 break;
             case OpenMode.CreateNoteTemplate:
-                void this.plugin.templater.create_new_note_from_template(
-                    item,
-                    this.creation_folder,
-                );
+                this.app.workspace.activeEditor?.editor ? 
+                    void this.plugin.templater.create_new_note_from_template(
+                        item,
+                        this.creation_folder,
+                    ) : 
+                    // Wait for editor initialization before template execution
+                    setTimeout(() => {
+                        void this.plugin.templater.create_new_note_from_template(
+                            item,
+                            this.creation_folder,
+                        );
+                    }, 100);
                 break;
         }
     }


### PR DESCRIPTION
## Summary

fix: resolve #1674 — When reading is the default mode for new tabs and you create a new note from a Base configured create a file in a folder, the folder template does not fully trigger

## Problem

**Severity**: `Medium` | **File**: `src/handlers/FuzzySuggester.ts`

Since the issue occurs when creating new notes through Base/folder creation, the fuzzy suggester logic may need to ensure proper template execution context, especially on mobile devices with reading view defaults.

## Solution

Review the folder template triggering logic in the fuzzy suggester to ensure it properly handles the mobile reading view scenario and waits for complete editor initialization before template execution.

## Changes

- `src/handlers/FuzzySuggester.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced