### PR TITLE
fix: resolve #1669 — Templates on new files don't add frontmatters combined with the "Current View" plug-in

### DIFF
--- a/src/editor/Editor.ts
+++ b/src/editor/Editor.ts
@@ -43,6 +43,18 @@ export class Editor {
         this.cursor_jumper = new CursorJumper(plugin.app);
         this.activeEditorExtensions = [];
     }
+    private cursor_jumper: CursorJumper;
+    private activeEditorExtensions: Array<Extension>;
+
+    // Note that this is `undefined` until `setup` has run.
+    private templaterLanguage: Extension | undefined;
+
+    private autocomplete: Autocomplete;
+
+    public constructor(private plugin: TemplaterPlugin) {
+        this.cursor_jumper = new CursorJumper(plugin.app);
+        this.activeEditorExtensions = [];
+    }
 
     desktopShouldHighlight(): boolean {
         return (
@@ -125,6 +137,26 @@ export class Editor {
             return;
         }
         await this.cursor_jumper.jump_to_next_cursor_location();
+    }
+
+    // Support editor operations in reading view context
+    async apply_template_in_reading_view(template_content: string): Promise<void> {
+        const active_view = this.plugin.app.workspace.getActiveViewOfType(
+            this.plugin.app.workspace.getLeavesOfType("markdown").first()?.view?.constructor
+        );
+        
+        if (active_view && active_view.editor) {
+            const editor = active_view.editor;
+            const cursor_pos = editor.getCursor();
+            editor.replaceRange(template_content, cursor_pos);
+        } else {
+            // Fallback: use workspace editor if available
+            const workspace_editor = this.plugin.app.workspace.activeEditor?.editor;
+            if (workspace_editor) {
+                const cursor_pos = workspace_editor.getCursor();
+                workspace_editor.replaceRange(template_content, cursor_pos);
+            }
+        }
     }
 
     async registerCodeMirrorMode(): Promise<void> {

--- a/src/handlers/EventHandler.ts
+++ b/src/handlers/EventHandler.ts
@@ -71,12 +71,15 @@ export default class EventHandler {
         if (this.settings.trigger_on_file_creation) {
             this.trigger_on_file_creation_event = this.plugin.app.vault.on(
                 "create",
-                (file: TAbstractFile) =>
+                async (file: TAbstractFile) => {
+                    // Wait for the file to be fully created and opened
+                    await this.plugin.app.workspace.onLayoutReady();
                     Templater.on_file_creation(
                         this.templater,
                         this.plugin.app,
                         file,
-                    ),
+                    );
+                },
             );
             this.plugin.registerEvent(this.trigger_on_file_creation_event);
         } else {


### PR DESCRIPTION
## Summary

fix: resolve #1669 — Templates on new files don't add frontmatters combined with the "Current View" plug-in

## Problem

**Severity**: `Medium` | **File**: `src/handlers/EventHandler.ts`

The event handler that triggers template application on new file creation may not properly handle cases where the file is opened in reading view by default. This needs to be updated to ensure templates are applied regardless of initial view mode.

## Solution



## Changes

- `src/handlers/EventHandler.ts` (modified)
- `src/editor/Editor.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced