### PR TITLE
feat: add autocomplete for object-exported user script functions

### DIFF
--- a/src/editor/TpDocumentation.ts
+++ b/src/editor/TpDocumentation.ts
@@ -1,6 +1,14 @@
 import TemplaterPlugin from "main";
+import { TFile } from "obsidian";
 import { errorWrapper } from "utils/Error";
-import { get_fn_params, get_tfiles_from_folder, is_object, populate_docs_from_user_scripts } from "utils/Utils";
+import { UserScriptFunctions } from "core/functions/user_functions/UserScriptFunctions";
+import type { UserScriptFunction } from "types";
+import {
+    get_fn_params,
+    get_tfiles_from_folder,
+    is_object,
+    populate_docs_from_user_scripts,
+} from "utils/Utils";
 import documentation from "../../docs/documentation.toml";
 
 const module_names = [
@@ -123,6 +131,21 @@ export class Documentation {
                 `Failed to parse user script documentation`,
             );
             if (!docFiles || docFiles.length === 0) return;
+
+            const userScriptPath = get_user_script_path(function_name);
+            if (userScriptPath) {
+                const userScriptFile = jsFiles.find(
+                    (file) => file.basename === userScriptPath.scriptName,
+                );
+                if (!userScriptFile) return [];
+
+                return get_user_script_object_documentation(
+                    this.plugin,
+                    userScriptFile,
+                    userScriptPath.scriptName,
+                );
+            }
+
             return docFiles.reduce<TpFunctionDocumentation[]>(
                 (acc, file) => [
                     ...acc,
@@ -235,4 +258,57 @@ export class Documentation {
         }
         return function_doc.args[argument_name];
     }
+}
+
+function get_user_script_path(
+    function_name: string,
+): { scriptName: string } | null {
+    const separatorIndex = function_name.indexOf(".");
+    if (separatorIndex === -1) {
+        return null;
+    }
+
+    const scriptName = function_name.slice(0, separatorIndex);
+    if (!scriptName) {
+        return null;
+    }
+
+    return { scriptName };
+}
+
+async function get_user_script_object_documentation(
+    plugin: TemplaterPlugin,
+    userScriptFile: TFile,
+    scriptName: string,
+): Promise<TpFunctionDocumentation[]> {
+    const userScriptFunctions = new Map<string, UserScriptFunction>();
+    const loader = new UserScriptFunctions(plugin);
+    await errorWrapper(
+        () =>
+            loader.load_user_script_function(
+                userScriptFile,
+                userScriptFunctions,
+            ),
+        `Failed to load user script at "${userScriptFile.path}"`,
+    );
+
+    const userScriptFunction = userScriptFunctions.get(scriptName);
+    if (!is_object(userScriptFunction)) {
+        return [];
+    }
+
+    return Object.entries(userScriptFunction)
+        .filter((entry): entry is [string, (...args: unknown[]) => unknown] => {
+            return typeof entry[1] === "function";
+        })
+        .map(([name, fn]) => ({
+            name,
+            queryKey: `${scriptName}.${name}`,
+            definition: `tp.user.${scriptName}.${name}(${get_fn_params(
+                fn,
+            ).join(", ")})`,
+            description: "",
+            returns: "",
+            example: "",
+        }));
 }

--- a/src/editor/TpDocumentation.ts
+++ b/src/editor/TpDocumentation.ts
@@ -4,6 +4,7 @@ import { errorWrapper } from "utils/Error";
 import { UserScriptFunctions } from "core/functions/user_functions/UserScriptFunctions";
 import type { UserScriptFunction } from "types";
 import {
+    generate_jsdoc_documentation,
     get_fn_params,
     get_tfiles_from_folder,
     is_object,
@@ -60,6 +61,14 @@ export type TpFunctionDocumentation = {
 export type TpArgumentDocumentation = {
     name: string;
     description: string;
+};
+
+type UserScriptMemberDocumentation = {
+    description: string;
+    returns: string;
+    args?: {
+        [key: string]: TpArgumentDocumentation;
+    };
 };
 
 export type TpSuggestDocumentation =
@@ -126,11 +135,6 @@ export class Documentation {
                 `User Scripts folder doesn't exist`,
             );
             if (!jsFiles || jsFiles.length === 0) return;
-            const docFiles = await errorWrapper(
-                () => populate_docs_from_user_scripts(this.plugin.app, jsFiles),
-                `Failed to parse user script documentation`,
-            );
-            if (!docFiles || docFiles.length === 0) return;
 
             const userScriptPath = get_user_script_path(function_name);
             if (userScriptPath) {
@@ -146,6 +150,12 @@ export class Documentation {
                 );
             }
 
+            const docFiles = await errorWrapper(
+                () => populate_docs_from_user_scripts(this.plugin.app, jsFiles),
+                `Failed to parse user script documentation`,
+            );
+            if (!docFiles || docFiles.length === 0) return;
+
             return docFiles.reduce<TpFunctionDocumentation[]>(
                 (acc, file) => [
                     ...acc,
@@ -155,15 +165,7 @@ export class Documentation {
                         definition: "",
                         description: file.description ?? "",
                         returns: file.returns ?? "",
-                        args: (file.arguments ?? []).reduce<{
-                            [key: string]: TpArgumentDocumentation;
-                        }>((argAcc, arg) => {
-                            argAcc[arg.name] = {
-                                name: arg.name,
-                                description: arg.description,
-                            };
-                            return argAcc;
-                        }, {}),
+                        args: get_argument_documentation(file.arguments ?? []),
                         example: "",
                     },
                 ],
@@ -281,6 +283,9 @@ async function get_user_script_object_documentation(
     userScriptFile: TFile,
     scriptName: string,
 ): Promise<TpFunctionDocumentation[]> {
+    const userScriptContent = await plugin.app.vault.cachedRead(userScriptFile);
+    const memberDocumentation =
+        get_user_script_member_documentation(userScriptContent);
     const userScriptFunctions = new Map<string, UserScriptFunction>();
     const loader = new UserScriptFunctions(plugin);
     await errorWrapper(
@@ -301,14 +306,76 @@ async function get_user_script_object_documentation(
         .filter((entry): entry is [string, (...args: unknown[]) => unknown] => {
             return typeof entry[1] === "function";
         })
-        .map(([name, fn]) => ({
-            name,
-            queryKey: `${scriptName}.${name}`,
-            definition: `tp.user.${scriptName}.${name}(${get_fn_params(
-                fn,
-            ).join(", ")})`,
-            description: "",
-            returns: "",
-            example: "",
-        }));
+        .map(([name, fn]) => {
+            const docs =
+                memberDocumentation.get(name) ||
+                memberDocumentation.get(fn.name);
+            return {
+                name,
+                queryKey: `${scriptName}.${name}`,
+                definition: `tp.user.${scriptName}.${name}(${get_fn_params(
+                    fn,
+                ).join(", ")})`,
+                description: docs?.description ?? "",
+                returns: docs?.returns ?? "",
+                args: docs?.args,
+                example: "",
+            };
+        });
+}
+
+function get_user_script_member_documentation(
+    content: string,
+): Map<string, UserScriptMemberDocumentation> {
+    const docs = new Map<string, UserScriptMemberDocumentation>();
+    const docBlock = "\\/\\*\\*[\\s\\S]*?\\*\\/";
+    const identifier = "[$A-Z_a-z][$\\w]*";
+    const patterns = [
+        new RegExp(
+            `(${docBlock})\\s*(?:async\\s+)?function\\s+(${identifier})\\s*\\(`,
+            "g",
+        ),
+        new RegExp(
+            `(${docBlock})\\s*(?:const|let|var)\\s+(${identifier})\\s*=`,
+            "g",
+        ),
+        new RegExp(`(${docBlock})\\s*(${identifier})\\s*:`, "g"),
+        new RegExp(`(${docBlock})\\s*["'](${identifier})["']\\s*:`, "g"),
+        new RegExp(
+            `(${docBlock})\\s*(?:async\\s+)?(${identifier})\\s*\\([^)]*\\)\\s*{`,
+            "g",
+        ),
+        new RegExp(`(${docBlock})\\s*(${identifier})\\s*(?=,|})`, "g"),
+    ];
+
+    for (const pattern of patterns) {
+        for (const match of content.matchAll(pattern)) {
+            const doc = generate_jsdoc_documentation(match[1]);
+            docs.set(match[2], {
+                description: doc.description,
+                returns: doc.returns,
+                args: get_argument_documentation(doc.arguments),
+            });
+        }
+    }
+
+    return docs;
+}
+
+function get_argument_documentation(
+    args: { name: string; description: string }[],
+): { [key: string]: TpArgumentDocumentation } | undefined {
+    if (args.length === 0) {
+        return undefined;
+    }
+
+    return args.reduce<{
+        [key: string]: TpArgumentDocumentation;
+    }>((argAcc, arg) => {
+        argAcc[arg.name] = {
+            name: arg.name,
+            description: arg.description,
+        };
+        return argAcc;
+    }, {});
 }

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -104,24 +104,33 @@ export async function populate_docs_from_user_scripts(
 }
 
 function generate_jsdoc(file: TFile, content: string): TJDocFile {
-    // Parse the content
-    const tsdocParser = new TSDocParser();
-    const parsedDoc = tsdocParser.parseString(content);
+    const doc = generate_jsdoc_documentation(content);
 
     // Copy and extract information into the TJDocFile
     const newDocFile = new TJDocFile(file);
 
-    newDocFile.description = generate_jsdoc_description(
-        parsedDoc.docComment.summarySection,
-    );
-    newDocFile.returns = generate_jsdoc_return(
-        parsedDoc.docComment.returnsBlock,
-    );
-    newDocFile.arguments = generate_jsdoc_arguments(
-        parsedDoc.docComment.params,
-    );
+    newDocFile.description = doc.description;
+    newDocFile.returns = doc.returns;
+    newDocFile.arguments = doc.arguments;
 
     return newDocFile;
+}
+
+export function generate_jsdoc_documentation(content: string): {
+    description: string;
+    returns: string;
+    arguments: TJDocFileArgument[];
+} {
+    const tsdocParser = new TSDocParser();
+    const parsedDoc = tsdocParser.parseString(content);
+
+    return {
+        description: generate_jsdoc_description(
+            parsedDoc.docComment.summarySection,
+        ),
+        returns: generate_jsdoc_return(parsedDoc.docComment.returnsBlock),
+        arguments: generate_jsdoc_arguments(parsedDoc.docComment.params),
+    };
 }
 
 function generate_jsdoc_description(summarySection: DocSection): string {

--- a/test/page-objects/EditorSuggestions.page.ts
+++ b/test/page-objects/EditorSuggestions.page.ts
@@ -16,9 +16,14 @@ class EditorSuggestions {
     }
 
     async getSuggestionNames(): Promise<string[]> {
+        const texts = await this.getSuggestionTexts();
+        return texts.map((text) => text.split("\n")[0]);
+    }
+
+    async getSuggestionTexts(): Promise<string[]> {
         const names: string[] = [];
         for await (const item of this.#suggestionEls) {
-            names.push((await item.getText()).split("\n")[0]);
+            names.push(await item.getText());
         }
         return names;
     }

--- a/test/specs/user-functions/user-function-autocomplete.e2e.ts
+++ b/test/specs/user-functions/user-function-autocomplete.e2e.ts
@@ -68,8 +68,13 @@ describe("User function autocomplete", () => {
     it("typing tp.user.<script>. with an object user script shows exported function suggestions", async () => {
         await resetVault("test/vault", {
             "user scripts/foo.js": [
-                "function doSomething() {",
-                `    return "Something was done";`,
+                "/**",
+                " * Does something from an object export.",
+                " * @param name - The name to use",
+                " * @returns The result message",
+                " */",
+                "function doSomething(name) {",
+                `    return "Something was done " + name;`,
                 "}",
                 "",
                 "module.exports = {",
@@ -86,6 +91,15 @@ describe("User function autocomplete", () => {
         const names = await EditorSuggestionsPage.getSuggestionNames();
         expect(names).toContain("func");
         expect(names).toContain("doSomething");
+        const texts = await EditorSuggestionsPage.getSuggestionTexts();
+        const doSomethingText = texts.find((text) =>
+            text.startsWith("doSomething"),
+        );
+        expect(doSomethingText).toContain(
+            "Does something from an object export.",
+        );
+        expect(doSomethingText).toContain("name: The name to use");
+        expect(doSomethingText).toContain("Returns: The result message");
     });
 
     it("typing tp.user. with nonexistent user scripts folder shows error notice", async () => {

--- a/test/specs/user-functions/user-function-autocomplete.e2e.ts
+++ b/test/specs/user-functions/user-function-autocomplete.e2e.ts
@@ -65,6 +65,29 @@ describe("User function autocomplete", () => {
         expect(names).toContain("greet");
     });
 
+    it("typing tp.user.<script>. with an object user script shows exported function suggestions", async () => {
+        await resetVault("test/vault", {
+            "user scripts/foo.js": [
+                "function doSomething() {",
+                `    return "Something was done";`,
+                "}",
+                "",
+                "module.exports = {",
+                "    func: () => console.log('test'),",
+                "    doSomething,",
+                "};",
+            ].join("\n"),
+            "notes/show object suggestions.md": `\n`,
+        });
+        await obsidianPage.openFile("notes/show object suggestions.md");
+        await ActiveMarkdownViewPage.typeText("tp.user.foo.");
+        await NoticePage.expectNoErrorNotice();
+        await EditorSuggestionsPage.waitForDisplayed();
+        const names = await EditorSuggestionsPage.getSuggestionNames();
+        expect(names).toContain("func");
+        expect(names).toContain("doSomething");
+    });
+
     it("typing tp.user. with nonexistent user scripts folder shows error notice", async () => {
         await resetVault("test/vault", {
             "notes/nonexistent scripts folder.md": `\n`,


### PR DESCRIPTION
Fixes #1752.

## Summary

This adds autocomplete for user scripts that export an object. Previously, `tp.user.` could suggest the script file, but `tp.user.<script>.` did not suggest function members from an object export. With this change, Templater loads the selected user script and suggests function-valued object members such as `func` and `doSomething`.

The PR also surfaces JSDoc/TSDoc-style documentation for documented object members, including parameter and return metadata in the completion details.

## Manual verification script

I used this minimal user script for the UI verification screenshots:

```js
/**
 * Does something from an object export.
 * @param name - The name to use
 * @returns The result message
 */
function doSomething(name) {
    return "Something was done " + name;
}

module.exports = {
    func: () => console.log("test"),
    doSomething,
};
```

## UI verification

Manual UI verification was done with Templater 2.20.5 + Obsidian 1.12.7, matching the version reported in the issue. The current development build requires Obsidian 1.13.0, which I could not download locally without an Obsidian Insiders account, so I ported this fix into a temporary 2.20.5 checkout for the manual UI check.

<table>
  <tr>
    <td align="center"><strong>Before: script file is suggested</strong></td>
    <td align="center"><strong>Before: object members are missing</strong></td>
  </tr>
  <tr>
    <td><img width="480" alt="Before: tp.user.fo suggests the foo script" src="https://github.com/user-attachments/assets/65834493-c439-4cfc-994b-38efa32c52d4" /></td>
    <td><img width="480" alt="Before: tp.user.foo. does not suggest object members" src="https://github.com/user-attachments/assets/927cbb16-01c1-44d3-9989-575636a8158e" /></td>
  </tr>
</table>

<strong>After: object members and documentation are suggested</strong>

<img width="720" alt="After: tp.user.foo. suggests func and doSomething with documentation" src="https://github.com/user-attachments/assets/1956b8d1-834e-4eaf-8982-5d5e9d286d64" />

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`
- `pnpm build`
- Manual UI verification with Templater 2.20.5 + Obsidian 1.12.7 as shown above

## Notes

This uses the existing user script loader to inspect the target script export shape for nested autocomplete, so completing `tp.user.<script>.` evaluates that user script in the same way runtime loading does.

I did not claim a passing WDIO run: a focused local WDIO run hung before producing spec output in this environment.
