### PR TITLE
Add configurable maxBuffer for user system commands

### DIFF
--- a/src/core/functions/user_functions/UserSystemFunctions.ts
+++ b/src/core/functions/user_functions/UserSystemFunctions.ts
@@ -82,6 +82,7 @@ export class UserSystemFunctions implements IGenerateObject {
                                 this.plugin.settings.command_timeout * 1000,
                             cwd: this.cwd,
                             env: process_env,
+                            maxBuffer: this.plugin.settings.command_max_buffer,
                             ...(this.plugin.settings.shell_path && {
                                 shell: this.plugin.settings.shell_path,
                             }),

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -42,6 +42,10 @@ export interface IgnoreFolderOnCreation {
 export const DEFAULT_SETTINGS: Settings = {
     data_version: 2,
     command_timeout: 5,
+    // Maximum stdout/stderr size (bytes) for user system commands.
+    // Overrides Node's 1 MiB `exec` default, which made commands with large
+    // output fail with "stdout maxBuffer length exceeded".
+    command_max_buffer: 1024 * 1024 * 100,
     templates_folder: "",
     templates_pairs: [],
     trigger_on_file_creation_mode: "none",
@@ -72,6 +76,7 @@ export interface Settings {
     file_templates: Array<FileTemplate>;
     ignore_folders_on_creation: Array<IgnoreFolderOnCreation>;
     command_timeout: number;
+    command_max_buffer: number;
     templates_pairs: Array<[string, string]>;
     shell_path: string;
     user_scripts_folder: string;


### PR DESCRIPTION
## Description

User system commands (User System Functions) run through Node's `child_process.exec`, which caps combined stdout at a default `maxBuffer` of 1 MiB and rejects with `stdout maxBuffer length exceeded` once a command produces more output than that. This is the failure reported in #1749.

This adds a `command_max_buffer` setting (default 100 MiB, in bytes) and passes it as `maxBuffer` in the exec options, so commands with large output no longer fail while the limit stays tunable. It mirrors the existing advanced `command_timeout` / `shell_path` settings (data-model settings without dedicated UI), so no migration is needed — `Object.assign({}, DEFAULT_SETTINGS, raw)` fills the default in for existing users.

Fixes #1749

## Testing

- `pnpm run typecheck` — pass
- `pnpm run lint` — pass
- `pnpm run build` — pass

I was not able to run the e2e suite locally, as it requires Obsidian 1.13 (Catalyst) per the discussion in the issue thread. Happy to adjust the default buffer size or the overall approach based on your preference.