### PR TITLE
feat: add language parameter to tp.web.daily_quote()

### DIFF
--- a/docs/documentation.toml
+++ b/docs/documentation.toml
@@ -680,12 +680,20 @@ description = "This modules contains every internal function related to the web 
 
 [tp.web.functions.daily_quote]
 name = "daily_quote"
-description = "Retrieves and parses the daily quote from `https://github.com/Zachatoo/quotes-database` as a callout."
-definition = "tp.web.daily_quote()"
+description = "Retrieves and parses a daily quote as a callout. Without arguments it uses the language configured in Obsidian (via `getLanguage()`), falling back to English. English quotes come from `https://github.com/Zachatoo/quotes-database` and Spanish quotes from `https://github.com/wulflo/frases-inventario`."
+definition = "tp.web.daily_quote(language?: string)"
+
+[[tp.web.functions.daily_quote.args]]
+name = "language"
+description = "Optional language code (e.g. `\"en\"`, `\"es\"`) selecting the quotes database. Defaults to Obsidian's display language, falling back to English when no database is registered for that language."
 
 [[tp.web.functions.daily_quote.examples]]
 name = "Daily quote"
 example = "<% await tp.web.daily_quote() %>"
+
+[[tp.web.functions.daily_quote.examples]]
+name = "Daily quote in Spanish"
+example = """<% await tp.web.daily_quote("es") %>"""
 
 [tp.web.functions.random_picture]
 name = "random_picture"

--- a/src/core/functions/internal_functions/web/InternalModuleWeb.ts
+++ b/src/core/functions/internal_functions/web/InternalModuleWeb.ts
@@ -1,4 +1,4 @@
-import { requestUrl, RequestUrlResponse } from "obsidian";
+import { getLanguage, requestUrl, RequestUrlResponse } from "obsidian";
 import { TemplaterError } from "utils/Error";
 import { InternalModule } from "../InternalModule";
 import { ModuleName } from "editor/TpDocumentation";
@@ -7,6 +7,18 @@ interface DailyQuote {
     quote: string;
     author: string;
 }
+
+const DEFAULT_QUOTE_LANGUAGE = "en";
+
+/**
+ * Quote databases keyed by language code. Each database is a JSON array of
+ * `{ quote, author }` objects. To add a language, register its database URL
+ * here — any language without an entry falls back to `DEFAULT_QUOTE_LANGUAGE`.
+ */
+const DAILY_QUOTE_DATABASES: Record<string, string> = {
+    en: "https://raw.githubusercontent.com/Zachatoo/quotes-database/refs/heads/main/quotes.json",
+    es: "https://raw.githubusercontent.com/wulflo/frases-inventario/refs/heads/main/quotes.json",
+};
 
 interface UnsplashPhoto {
     full: string;
@@ -42,12 +54,21 @@ export class InternalModuleWeb extends InternalModule {
         }
     }
 
-    generate_daily_quote(): () => Promise<string> {
-        return async () => {
+    generate_daily_quote(): (language?: string) => Promise<string> {
+        return async (language?: string) => {
             try {
-                const response = await this.getRequest(
-                    "https://raw.githubusercontent.com/Zachatoo/quotes-database/refs/heads/main/quotes.json",
-                );
+                // Resolve the quote language: an explicit argument wins, then
+                // Obsidian's display language, then the English default.
+                const lang = (
+                    language ||
+                    getLanguage() ||
+                    DEFAULT_QUOTE_LANGUAGE
+                ).toLowerCase();
+                const database =
+                    DAILY_QUOTE_DATABASES[lang] ??
+                    DAILY_QUOTE_DATABASES[DEFAULT_QUOTE_LANGUAGE];
+
+                const response = await this.getRequest(database);
                 const quotes = response.json as DailyQuote[];
                 const random_quote =
                     quotes[Math.floor(Math.random() * quotes.length)];


### PR DESCRIPTION
## What

Adds an optional `language` parameter to `tp.web.daily_quote()` so it can return quotes in languages other than English, closing #1757.

```js
<% await tp.web.daily_quote() %>      // Obsidian's display language, falls back to English
<% await tp.web.daily_quote("en") %>  // English
<% await tp.web.daily_quote("es") %>  // Spanish
```

This follows the API shape proposed in the issue discussion: with no argument it resolves the language from Obsidian's own `getLanguage()` and falls back to English, so the common case keeps working unchanged and matches the user's locale automatically.

## How

- `generate_daily_quote()` now takes `language?: string`. Resolution order: explicit argument → `getLanguage()` → `"en"`.
- Quote databases live in a small `DAILY_QUOTE_DATABASES` map keyed by language code. Adding a language is now a one-line change; any language without an entry falls back to English, so this can't break existing behaviour.
  - `en` → the existing `Zachatoo/quotes-database`
  - `es` → `wulflo/frases-inventario` (the curated Spanish dataset offered by the issue author)
- Documentation (`docs/documentation.toml`) updated: new `language` arg + a Spanish example.

## Verification

- I confirmed the Spanish dataset is a drop-in replacement: same `{ quote, author }` JSON shape as the English database, 792 entries, live.
- `eslint` passes on the changed file; `tsc` reports no errors introduced by this change.

## Note for maintainers

Both databases are third-party `raw.githubusercontent.com` sources (as the English one already is). If you'd prefer the Spanish source to be mirrored/pinned under an account you control for longevity, happy to adjust — just let me know.

Closes #1757
