### PR TITLE
feat(prompt): Added ability to auto select default text in system prompt

### DIFF
--- a/docs/documentation.toml
+++ b/docs/documentation.toml
@@ -514,7 +514,7 @@ example = "<% tp.system.clipboard() %>"
 [tp.system.functions.prompt]
 name = "prompt"
 description = "Spawns a prompt modal and returns the user's input."
-definition = "tp.system.prompt(prompt_text?: string, default_value?: string, throw_on_cancel: boolean = false, multiline?: boolean = false)"
+definition = "tp.system.prompt(prompt_text?: string, default_value?: string, throw_on_cancel: boolean = false, multiline?: boolean = false, select_default_value?: boolean = false)"
 
 [[tp.system.functions.prompt.args]]
 name = "prompt_text"
@@ -532,6 +532,10 @@ description = "Throws an error if the prompt is canceled, instead of returning a
 name = "multiline"
 description = "If set to `true`, the input field will be a multiline textarea. Defaults to `false`."
 
+[[tp.system.functions.prompt.args]]
+name = "select_default_value"
+description = "If set to `true`, the default value shown when the modal opens is selected, so typing replaces it. Defaults to `false`."
+
 [[tp.system.functions.prompt.examples]]
 name = "Prompt"
 example = """<% await tp.system.prompt("Please enter a value") %>"""
@@ -543,6 +547,10 @@ example = """<% await tp.system.prompt("What is your mood today?", "happy") %>""
 [[tp.system.functions.prompt.examples]]
 name = "Multiline prompt"
 example = """<% await tp.system.prompt("What is your mood today?", null, false, true) %>"""
+
+[[tp.system.functions.prompt.examples]]
+name = "Prompt with pre-selected default value"
+example = """<% await tp.system.prompt("What is your mood today?", "Input a mood...", false, false, true) %>"""
 
 [[tp.system.functions.prompt.examples]]
 name = "Reuse output from prompt"

--- a/src/core/functions/internal_functions/system/InternalModuleSystem.ts
+++ b/src/core/functions/internal_functions/system/InternalModuleSystem.ts
@@ -32,19 +32,22 @@ export class InternalModuleSystem extends InternalModule {
         prompt_text: string,
         default_value: string,
         throw_on_cancel: boolean,
-        multi_line: boolean
+        multi_line: boolean,
+        select_default_value: boolean
     ) => Promise<string | null> {
         return async (
             prompt_text: string,
             default_value: string,
             throw_on_cancel = false,
-            multi_line = false
+            multi_line = false,
+            select_default_value = false
         ): Promise<string | null> => {
             const prompt = new PromptModal(
                 this.plugin.app,
                 prompt_text,
                 default_value,
-                multi_line
+                multi_line,
+                select_default_value
             );
             const promise = new Promise(
                 (

--- a/src/core/functions/internal_functions/system/PromptModal.ts
+++ b/src/core/functions/internal_functions/system/PromptModal.ts
@@ -19,6 +19,7 @@ export class PromptModal extends Modal {
         private prompt_text: string,
         private default_value: string,
         private multi_line: boolean,
+        private select_default_value: boolean,
     ) {
         super(app);
     }
@@ -62,6 +63,9 @@ export class PromptModal extends Modal {
         textInput.setValue(this.value);
         textInput.onChange((value) => (this.value = value));
         textInput.inputEl.focus();
+        if (this.select_default_value) {
+            textInput.inputEl.select();
+        }
         textInput.inputEl.addEventListener("keydown", (evt: KeyboardEvent) =>
             this.enterCallback(evt),
         );

--- a/test/page-objects/PromptModal.page.ts
+++ b/test/page-objects/PromptModal.page.ts
@@ -33,6 +33,16 @@ class PromptModal {
         );
     }
 
+    async getSelectedText() {
+        await this.waitForDisplayed();
+        return browser.execute((selector: string) => {
+            const el = activeDocument.querySelector(selector) as
+                | HTMLInputElement
+                | HTMLTextAreaElement;
+            return el.value.substring(el.selectionStart ?? 0, el.selectionEnd ?? 0);
+        }, ".templater-prompt-input");
+    }
+
     async submit() {
         await this.waitForDisplayed();
         await browser.keys("Enter");

--- a/test/specs/internal-modules/system.e2e.ts
+++ b/test/specs/internal-modules/system.e2e.ts
@@ -129,6 +129,39 @@ describe("InternalModuleSystem", () => {
         await VaultPage.expectFileToHaveContent("Untitled.md", "");
     });
 
+    it("tp.system.prompt selects default value when select_default_value is true", async () => {
+        await resetVault("test/vault", {
+            "templates/tp.system.prompt.md": `<% await tp.system.prompt("Enter a value", "default text", false, false, true) %>`,
+        });
+        await EmptyStateViewPage.clickCreateNewNote();
+        await WorkspacePage.expectActiveTabToHaveText("Untitled");
+        await OpenInsertTemplateModalPage.open();
+        await OpenInsertTemplateModalPage.selectSuggestionByName(
+            "tp.system.prompt",
+        );
+        expect(await PromptModalPage.getSelectedText()).toBe("default text");
+        await PromptModalPage.enterValue("replaced text");
+        await PromptModalPage.submit();
+        await WorkspacePage.waitForAllTemplatesExecuted();
+        await VaultPage.expectFileToHaveContent("Untitled.md", "replaced text");
+    });
+
+    it("tp.system.prompt does not select default value by default", async () => {
+        await resetVault("test/vault", {
+            "templates/tp.system.prompt.md": `<% await tp.system.prompt("Enter a value", "default text") %>`,
+        });
+        await EmptyStateViewPage.clickCreateNewNote();
+        await WorkspacePage.expectActiveTabToHaveText("Untitled");
+        await OpenInsertTemplateModalPage.open();
+        await OpenInsertTemplateModalPage.selectSuggestionByName(
+            "tp.system.prompt",
+        );
+        expect(await PromptModalPage.getSelectedText()).toBe("");
+        await PromptModalPage.submit();
+        await WorkspacePage.waitForAllTemplatesExecuted();
+        await VaultPage.expectFileToHaveContent("Untitled.md", "default text");
+    });
+
     it("tp.system.prompt supports multi-line input", async () => {
         await resetVault("test/vault", {
             "templates/tp.system.prompt.md": `<% await tp.system.prompt("Enter text", "", false, true) %>`,


### PR DESCRIPTION
# feat(system): add `select_default_value` option to `tp.system.prompt`

## Summary

Adds a new optional argument, `select_default_value`, to `tp.system.prompt`. When
set to `true`, the default value shown when the prompt modal opens is
selected/highlighted, so the user can immediately overwrite it by typing. When
`false` (the default), behavior is unchanged.

**New signature:**

```js
tp.system.prompt(
  prompt_text?,
  default_value?,
  throw_on_cancel = false,
  multiline = false,
  select_default_value = false
)
```

## Motivation

When a prompt is opened with a default value, users often want to replace it
rather than append to it. Without this option, the cursor is placed at the end
of the pre-filled text, forcing the user to manually clear it first.

## Usage

```js
// Opens with "Input a mood..." pre-selected so typing replaces it
example = """<% await tp.system.prompt("What is your mood today?", "Input a mood...", false, false, true) %>"""
```

## Backward compatibility

Fully backward compatible. The new parameter is optional and defaults to
`false`, so existing calls to `tp.system.prompt` are unaffected.

Closes #1760 