### PR TITLE
fix: Attempt to merge contents when multiple plugins updating same file at once

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
         "@microsoft/tsdoc": "^0.15.1",
         "@silentvoid13/rusty_engine": "^0.4.0",
         "acorn": "^8.17.0",
-        "child_process": "^1.0.2"
+        "child_process": "^1.0.2",
+        "diff-match-patch-es": "^1.0.1"
     },
     "config": {
         "commitizen": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       child_process:
         specifier: ^1.0.2
         version: 1.0.2
+      diff-match-patch-es:
+        specifier: ^1.0.1
+        version: 1.0.1
     devDependencies:
       '@eslint/js':
         specifier: ^9.35.0
@@ -1575,6 +1578,9 @@ packages:
 
   detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
+
+  diff-match-patch-es@1.0.1:
+    resolution: {integrity: sha512-KhSofrZDERg/NE6Nd+TK53knp2qz0o2Ix8rhkXd3Chfm7Wlo58Eq/juNmkyS6bS+3xS26L3Pstz3BdY/q+e9UQ==}
 
   diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
@@ -5911,6 +5917,8 @@ snapshots:
 
   detect-node@2.1.0:
     optional: true
+
+  diff-match-patch-es@1.0.1: {}
 
   diff@4.0.2: {}
 

--- a/src/core/Templater.ts
+++ b/src/core/Templater.ts
@@ -4,19 +4,20 @@ import {
     MarkdownPostProcessorContext,
     MarkdownView,
     normalizePath,
-    stringifyYaml,
     TAbstractFile,
     TFile,
     TFolder,
 } from "obsidian";
 import {
+    CommitResult,
     delay,
     generate_dynamic_command_regex,
     get_active_file,
     get_folder_path_from_file_path,
     resolve_tfile,
     get_frontmatter_and_content,
-    merge_objects,
+    merge_output_into_content,
+    merge_rendered_output,
 } from "utils/Utils";
 import TemplaterPlugin from "main";
 import {
@@ -208,11 +209,20 @@ export class Templater {
             return;
         }
 
-        await this.plugin.app.vault.modify(created_note, output_content);
+        // Another plugin may have written to the note while the template was running
+        // https://github.com/SilentVoid13/Templater/issues/1629
+        let written_content = output_content;
+        await this.plugin.app.vault.process(created_note, (data) => {
+            written_content =
+                data === ""
+                    ? output_content
+                    : merge_output_into_content(data, output_content);
+            return written_content;
+        });
 
         this.plugin.app.workspace.trigger("templater:new-note-from-template", {
             file: created_note,
-            content: output_content,
+            content: written_content,
         });
 
         if (open_new_note) {
@@ -312,10 +322,6 @@ export class Templater {
     ): Promise<void> {
         const { path } = file;
         this.start_templater_task(path);
-        const active_view =
-            this.plugin.app.workspace.getActiveViewOfType(MarkdownView);
-        const active_editor = this.plugin.app.workspace.activeEditor;
-        const active_file = get_active_file(this.plugin.app);
         const running_config = this.create_running_config(
             template_file,
             file,
@@ -331,26 +337,24 @@ export class Templater {
             return;
         }
 
-        const {
-            content: output_content_body,
-            frontmatter: output_frontmatter,
-        } = get_frontmatter_and_content(output_content);
+        // The active file can change while the template is running (e.g. waiting
+        // on a prompt), so resolve the editor after parsing rather than before
+        const active_view =
+            this.plugin.app.workspace.getActiveViewOfType(MarkdownView);
+        const active_editor = this.plugin.app.workspace.activeEditor;
+        const active_file = get_active_file(this.plugin.app);
         if (
             active_file?.path === file.path &&
             active_editor &&
             active_editor.editor &&
             active_view
         ) {
-            let result = "";
-            const { content, frontmatter } = get_frontmatter_and_content(
+            const result = merge_output_into_content(
                 active_editor.editor.getValue(),
+                output_content,
             );
-            merge_objects(frontmatter, output_frontmatter);
-            if (Object.keys(frontmatter).length > 0) {
-                result += `---\n${stringifyYaml(frontmatter)}---\n`;
-            }
-            result += content + output_content_body;
             active_editor.editor.setValue(result);
+            output_content = result;
             // Set cursor to first line of editor (below properties)
             // https://github.com/SilentVoid13/Templater/issues/1231
             const editor = active_editor.editor;
@@ -362,16 +366,11 @@ export class Templater {
             await active_view.save();
         } else {
             await this.plugin.app.vault.process(file, (data) => {
-                let result = "";
-                const { content, frontmatter } =
-                    get_frontmatter_and_content(data);
-                merge_objects(frontmatter, output_frontmatter);
-                if (Object.keys(frontmatter).length > 0) {
-                    result += `---\n${stringifyYaml(frontmatter)}---\n`;
-                }
-                result += content + output_content_body;
-                output_content = result;
-                return result;
+                output_content = merge_output_into_content(
+                    data,
+                    output_content,
+                );
+                return output_content;
             });
         }
         this.plugin.app.workspace.trigger("templater:new-note-from-template", {
@@ -415,19 +414,82 @@ export class Templater {
             file,
             active_file ? RunMode.OverwriteActiveFile : RunMode.OverwriteFile,
         );
-        const output_content = await errorWrapper(
-            async () => this.read_and_parse_template(running_config),
-            "Template parsing error, aborting.",
-        );
+        // Keep the content the template was parsed from, so concurrent
+        // changes can be detected when writing the output back
+        let snapshot = "";
+        const output_content = await errorWrapper(async () => {
+            snapshot = await this.plugin.app.vault.read(file);
+            return this.parse_template(running_config, snapshot);
+        }, "Template parsing error, aborting.");
         // errorWrapper failed
         if (output_content == null) {
             await this.end_templater_task(path);
             return;
         }
-        await this.plugin.app.vault.modify(file, output_content);
+        // Don't write (or touch mtime) if there's nothing to change
+        // https://github.com/SilentVoid13/Templater/issues/1719
+        // https://github.com/SilentVoid13/Templater/issues/1755
+        if (output_content === snapshot) {
+            await this.end_templater_task(path);
+            return;
+        }
+        if (!this.plugin.app.vault.getAbstractFileByPath(file.path)) {
+            log_error(
+                new TemplaterError(
+                    `${file.path} was deleted while the template was running, the template output was not applied.`,
+                ),
+            );
+            await this.end_templater_task(path);
+            return;
+        }
+        // If the file is now open in the active editor, write through the
+        // editor so unsaved changes aren't dropped
+        const active_editor = this.plugin.app.workspace.activeEditor;
+        let result: CommitResult;
+        if (active_editor?.file?.path === file.path && active_editor.editor) {
+            result = merge_rendered_output(
+                snapshot,
+                output_content,
+                active_editor.editor.getValue(),
+            );
+            if (result.status !== "conflict") {
+                active_editor.editor.setValue(result.content);
+                const active_view =
+                    this.plugin.app.workspace.getActiveViewOfType(
+                        MarkdownView,
+                    );
+                if (active_view) {
+                    // Wait for view to finish rendering properties widget
+                    await delay(100);
+                    // Save the file to ensure modifications saved to disk by the time `on_all_templates_executed` callback is executed
+                    // https://github.com/SilentVoid13/Templater/issues/1569
+                    await active_view.save();
+                }
+            }
+        } else {
+            result = { status: "clean", content: output_content };
+            await this.plugin.app.vault.process(file, (current) => {
+                result = merge_rendered_output(
+                    snapshot,
+                    output_content,
+                    current,
+                );
+                return result.content;
+            });
+        }
+        if (result.status === "conflict") {
+            log_error(
+                new TemplaterError(
+                    `${file.path} changed while the template was running, the template output was not applied.`,
+                    `Unapplied template output:\n${output_content}`,
+                ),
+            );
+            await this.end_templater_task(path);
+            return;
+        }
         this.plugin.app.workspace.trigger("templater:overwrite-file", {
             file,
-            content: output_content,
+            content: result.content,
         });
         await this.plugin.editor_handler.jump_to_next_cursor_location(
             file,

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -10,16 +10,19 @@ import {
 import { TJDocFile, TJDocFileArgument } from "./TJDocFile";
 
 import { TemplaterError } from "./Error";
+import { log_error } from "./Log";
 import {
     App,
     getFrontMatterInfo,
     normalizePath,
     parseYaml,
+    stringifyYaml,
     TAbstractFile,
     TFile,
     TFolder,
     Vault,
 } from "obsidian";
+import { patchApply, patchMake } from "diff-match-patch-es";
 
 export function delay(ms: number): Promise<void> {
     return new Promise((resolve) => window.setTimeout(resolve, ms));
@@ -253,6 +256,8 @@ export function append_bolded_label_with_value_to_parent(
 
 /**
  * Merges two objects recursively. Target object will be modified.
+ * Arrays are concatenated and deduplicated, and empty source values
+ * don't overwrite existing target values.
  * @param target The target object to merge into.
  * @param source The source object to merge from.
  */
@@ -310,4 +315,90 @@ export function get_frontmatter_and_content(content: string) {
         frontmatter,
         content: content.slice(front_matter_info.contentStart),
     };
+}
+
+/**
+ * Merges rendered template output into a file's existing content: the
+ * template's frontmatter is merged into the existing frontmatter and the
+ * template's body is appended to the existing body.
+ * Only parses/re-stringifies the existing frontmatter when the template
+ * actually contributes frontmatter, so comments and formatting are
+ * preserved otherwise.
+ */
+export function merge_output_into_content(
+    existing: string,
+    output: string,
+): string {
+    const output_fm_info = getFrontMatterInfo(output);
+    const output_body = output.slice(output_fm_info.contentStart);
+    if (!output_fm_info.exists) {
+        return existing + output_body;
+    }
+    const existing_fm_info = getFrontMatterInfo(existing);
+    if (!existing_fm_info.exists) {
+        return (
+            output.slice(0, output_fm_info.contentStart) +
+            existing +
+            output_body
+        );
+    }
+    let existing_frontmatter: Record<string, unknown>;
+    let output_frontmatter: Record<string, unknown>;
+    try {
+        existing_frontmatter = (parseYaml(existing_fm_info.frontmatter) ??
+            {}) as Record<string, unknown>;
+        output_frontmatter = (parseYaml(output_fm_info.frontmatter) ??
+            {}) as Record<string, unknown>;
+    } catch (e) {
+        // Can't merge invalid YAML, append the body without it rather than
+        // ending up with two frontmatter blocks
+        log_error(
+            new TemplaterError(
+                "Couldn't merge the template's properties into the note because one of them contains invalid YAML. The template body was appended without them.",
+                e instanceof Error ? e.message : String(e),
+            ),
+        );
+        return existing + output_body;
+    }
+    merge_objects(existing_frontmatter, output_frontmatter);
+    const existing_body = existing.slice(existing_fm_info.contentStart);
+    let result = "";
+    if (Object.keys(existing_frontmatter).length > 0) {
+        result += `---\n${stringifyYaml(existing_frontmatter)}---\n`;
+    }
+    return result + existing_body + output_body;
+}
+
+export type CommitResult = {
+    status: "clean" | "merged" | "conflict";
+    content: string;
+};
+
+/**
+ * Computes the content to write for a file whose template `output` was
+ * rendered from a `snapshot` that may be out of date, since other plugins can
+ * write to the file while a template runs. If the file changed, the
+ * template's edits are re-applied onto `current` as a three-way merge.
+ * All-or-nothing: if any hunk fails to apply the result is a conflict and
+ * `content` is `current`, unchanged. Templates are never re-evaluated
+ * because evaluation can have side effects.
+ * https://github.com/SilentVoid13/Templater/issues/1629
+ */
+export function merge_rendered_output(
+    snapshot: string,
+    output: string,
+    current: string,
+): CommitResult {
+    if (current === snapshot) {
+        return { status: "clean", content: output };
+    }
+    const patches = patchMake(snapshot, output);
+    const [merged, applied] = patchApply(patches, current) as [
+        string,
+        boolean[],
+    ];
+    if (applied.every((ok) => ok)) {
+        return { status: "merged", content: merged };
+    }
+    return { status: "conflict", content: current };
 }

--- a/test/page-objects/Notice.page.ts
+++ b/test/page-objects/Notice.page.ts
@@ -53,6 +53,22 @@ class Notice {
         );
     }
 
+    async expectTemplateOutputNotAppliedNotice(filePath: string) {
+        await this.expectNoticeElWithText(
+            "Templater error:\n" +
+                `${filePath} changed while the template was running, the template output was not applied.\n` +
+                "Check console for more information",
+        );
+    }
+
+    async expectFrontmatterMergeFailedNotice() {
+        await this.expectNoticeElWithText(
+            "Templater error:\n" +
+                "Couldn't merge the template's properties into the note because one of them contains invalid YAML. The template body was appended without them.\n" +
+                "Check console for more information",
+        );
+    }
+
     async expectNoErrorNotice() {
         // eslint-disable-next-line wdio/no-pause
         await browser.pause(500);

--- a/test/specs/race-condition.e2e.ts
+++ b/test/specs/race-condition.e2e.ts
@@ -1,0 +1,292 @@
+import { browser } from "@wdio/globals";
+import NoticePage from "../page-objects/Notice.page";
+import VaultPage from "../page-objects/Vault.page";
+import WorkspacePage from "../page-objects/Workspace.page";
+import { resetVault } from "../utils/reset-vault";
+
+// Counts its evaluations and takes 2s to finish, leaving a window
+// to write to the file while the template is running
+const SLOW_COMMAND =
+    "<%* window.__templaterEvalCount = (window.__templaterEvalCount ?? 0) + 1; " +
+    'await new Promise((resolve) => setTimeout(resolve, 2000)); tR += "rendered"; %>';
+
+describe("concurrent writes during template execution", () => {
+    afterEach(async () => {
+        await browser.executeObsidian(async ({ app, plugins }) => {
+            plugins.templaterObsidian.settings.trigger_on_file_creation_mode =
+                "none";
+            plugins.templaterObsidian.settings.folder_templates = [];
+            await plugins.templaterObsidian.save_settings();
+            app.saveLocalStorage("templater-local-settings", {
+                trigger_on_file_creation: false,
+            });
+        });
+    });
+
+    it("merges a concurrent write into the template output instead of clobbering it", async () => {
+        await resetVault("test/vault", {});
+        await browser.executeObsidian(({ app }) => {
+            app.saveLocalStorage("templater-local-settings", {
+                trigger_on_file_creation: true,
+            });
+        });
+
+        await browser.executeObsidian(
+            async ({ app }, slowCommand: string) => {
+                const w = window as unknown as {
+                    __templaterEvalCount?: number;
+                };
+                w.__templaterEvalCount = 0;
+                const file = await app.vault.create(
+                    "notes/race.md",
+                    `start\n${slowCommand}\nend`,
+                );
+                // Write to the file while the template is still evaluating
+                await new Promise((resolve) => setTimeout(resolve, 1000));
+                await app.vault.process(
+                    file,
+                    (content) => content + "\nconcurrent-write",
+                );
+            },
+            SLOW_COMMAND,
+        );
+
+        await WorkspacePage.waitForAllTemplatesExecuted();
+        await VaultPage.expectFileToHaveContent(
+            "notes/race.md",
+            "start\nrendered\nend\nconcurrent-write",
+        );
+        const evalCount = await browser.execute(
+            () =>
+                (window as unknown as { __templaterEvalCount?: number })
+                    .__templaterEvalCount,
+        );
+        expect(evalCount).toBe(1);
+    });
+
+    it("keeps the concurrent content and shows a notice when the template output can't be merged", async () => {
+        await resetVault("test/vault", {});
+        await browser.executeObsidian(({ app }) => {
+            app.saveLocalStorage("templater-local-settings", {
+                trigger_on_file_creation: true,
+            });
+        });
+
+        await browser.executeObsidian(
+            async ({ app }, slowCommand: string) => {
+                const file = await app.vault.create(
+                    "notes/conflict.md",
+                    `alpha\n${slowCommand}\nomega`,
+                );
+                await new Promise((resolve) => setTimeout(resolve, 1000));
+                // Rewrite the whole note so the template output can't be merged
+                await app.vault.process(
+                    file,
+                    () => "unrelated full rewrite of the note",
+                );
+            },
+            SLOW_COMMAND,
+        );
+
+        await WorkspacePage.waitForAllTemplatesExecuted();
+        await VaultPage.expectFileToHaveContent(
+            "notes/conflict.md",
+            "unrelated full rewrite of the note",
+        );
+        await NoticePage.expectTemplateOutputNotAppliedNotice(
+            "notes/conflict.md",
+        );
+    });
+
+    it("does not write at all when a new file contains no template commands", async () => {
+        await resetVault("test/vault", {});
+        await browser.executeObsidian(({ app }) => {
+            app.saveLocalStorage("templater-local-settings", {
+                trigger_on_file_creation: true,
+            });
+        });
+
+        const mtimeAfterCreate = await browser.executeObsidian(
+            async ({ app }) => {
+                const w = window as unknown as {
+                    __overwriteEventFired?: boolean;
+                    __overwriteEventRef?: unknown;
+                };
+                w.__overwriteEventFired = false;
+                const workspace = app.workspace as unknown as {
+                    on(name: string, callback: () => void): unknown;
+                };
+                w.__overwriteEventRef = workspace.on(
+                    "templater:overwrite-file",
+                    () => {
+                        w.__overwriteEventFired = true;
+                    },
+                );
+                const file = await app.vault.create(
+                    "notes/plain.md",
+                    "just some plain content",
+                );
+                return file.stat.mtime;
+            },
+        );
+
+        // Wait longer than the 300ms delay inside on_file_creation, then
+        // confirm Templater has finished before reading the file state.
+        // eslint-disable-next-line wdio/no-pause
+        await browser.pause(600);
+        await WorkspacePage.waitForAllTemplatesExecuted();
+
+        const { mtime, overwriteEventFired } = await browser.executeObsidian(
+            ({ app }) => {
+                const w = window as unknown as {
+                    __overwriteEventFired?: boolean;
+                    __overwriteEventRef?: unknown;
+                };
+                const workspace = app.workspace as unknown as {
+                    offref(ref: unknown): void;
+                };
+                if (w.__overwriteEventRef) {
+                    workspace.offref(w.__overwriteEventRef);
+                }
+                return {
+                    mtime: app.vault.getFileByPath("notes/plain.md")?.stat
+                        .mtime,
+                    overwriteEventFired: w.__overwriteEventFired,
+                };
+            },
+        );
+
+        await VaultPage.expectFileToHaveContent(
+            "notes/plain.md",
+            "just some plain content",
+        );
+        expect(mtime).toBe(mtimeAfterCreate);
+        expect(overwriteEventFired).toBe(false);
+    });
+
+    it("preserves content written by another create-event handler while create-new-note-from-template runs", async () => {
+        await resetVault("test/vault", {
+            "templates/slow.md":
+                "<%* await new Promise((resolve) => setTimeout(resolve, 1500)); %>template-output",
+        });
+
+        await browser.executeObsidian(({ app }) => {
+            const w = window as unknown as { __createEventRef?: unknown };
+            // Mimic another plugin filling new notes with content
+            w.__createEventRef = app.vault.on("create", (created) => {
+                if (created.path === "race-note.md") {
+                    const file = app.vault.getFileByPath(created.path);
+                    if (file) {
+                        void app.vault.process(
+                            file,
+                            () => "injected-by-other-plugin\n",
+                        );
+                    }
+                }
+            });
+        });
+
+        await browser.executeObsidian(async ({ app, plugins }) => {
+            const templateFile = app.vault.getFileByPath("templates/slow.md");
+            if (!templateFile) throw new Error("Template file not found");
+            await plugins.templaterObsidian.templater.create_new_note_from_template(
+                templateFile,
+                "",
+                "race-note",
+                false,
+            );
+        });
+
+        await browser.executeObsidian(({ app }) => {
+            const w = window as unknown as { __createEventRef?: unknown };
+            const vault = app.vault as unknown as {
+                offref(ref: unknown): void;
+            };
+            if (w.__createEventRef) {
+                vault.offref(w.__createEventRef);
+            }
+        });
+
+        await VaultPage.expectFileToHaveContent(
+            "race-note.md",
+            "injected-by-other-plugin\ntemplate-output",
+        );
+    });
+});
+
+describe("frontmatter merging on new file creation", () => {
+    async function setupFolderTemplate(templateContent: string) {
+        await resetVault("test/vault", {
+            "templates/t.md": templateContent,
+        });
+        await browser.executeObsidian(async ({ app, plugins }) => {
+            plugins.templaterObsidian.settings.templates_folder = "templates";
+            plugins.templaterObsidian.settings.trigger_on_file_creation_mode =
+                "folder";
+            plugins.templaterObsidian.settings.folder_templates = [
+                { folder: "notes", template: "templates/t.md" },
+            ];
+            await plugins.templaterObsidian.save_settings();
+            app.saveLocalStorage("templater-local-settings", {
+                trigger_on_file_creation: true,
+            });
+        });
+    }
+
+    afterEach(async () => {
+        await browser.executeObsidian(async ({ app, plugins }) => {
+            plugins.templaterObsidian.settings.trigger_on_file_creation_mode =
+                "none";
+            plugins.templaterObsidian.settings.folder_templates = [];
+            await plugins.templaterObsidian.save_settings();
+            app.saveLocalStorage("templater-local-settings", {
+                trigger_on_file_creation: false,
+            });
+        });
+    });
+
+    it("keeps the existing frontmatter block byte-identical when the template has no frontmatter", async () => {
+        await setupFolderTemplate("body-from-template");
+        await browser.executeObsidian(async ({ app }) => {
+            await app.vault.create(
+                "notes/props-only.md",
+                "---\nfoo: bar # keep me\n---\n",
+            );
+        });
+        await VaultPage.expectFileToHaveContent(
+            "notes/props-only.md",
+            "---\nfoo: bar # keep me\n---\nbody-from-template",
+        );
+    });
+
+    it("merges frontmatter from both sides, unioning arrays", async () => {
+        await setupFolderTemplate(
+            "---\ntags:\n  - from-template\n---\ntemplate-body",
+        );
+        await browser.executeObsidian(async ({ app }) => {
+            await app.vault.create(
+                "notes/props-merge.md",
+                "---\ntags:\n  - existing\nfoo: bar\n---\n",
+            );
+        });
+        await VaultPage.expectFileToHaveContent(
+            "notes/props-merge.md",
+            "---\ntags:\n  - existing\n  - from-template\nfoo: bar\n---\ntemplate-body",
+        );
+    });
+
+    it("never emits a second frontmatter block when the existing frontmatter is invalid YAML", async () => {
+        await setupFolderTemplate("---\nbar: baz\n---\ntemplate-body");
+        await browser.executeObsidian(async ({ app }) => {
+            await app.vault.create(
+                "notes/props-invalid.md",
+                "---\nfoo: [unclosed\n---\n",
+            );
+        });
+        await VaultPage.expectFileToHaveContent(
+            "notes/props-invalid.md",
+            "---\nfoo: [unclosed\n---\ntemplate-body",
+        );
+        await NoticePage.expectFrontmatterMergeFailedNotice();
+    });
+});


### PR DESCRIPTION
Use `diff-match-patch-es` for diffing and merging. Show a notice when template output can't be merged.

refs: #1629, #1719, #1755, #1776