### PR TITLE
fix(cli): preserve root-level output file names

### DIFF
--- a/src/handlers/CommandHandler.ts
+++ b/src/handlers/CommandHandler.ts
@@ -218,7 +218,7 @@ export class CommandHandler {
             const file_path = normalizePath(file);
             const folder_path = get_folder_path_from_file_path(file_path);
             const filename = file_path
-                .slice(folder_path.length + 1)
+                .slice(folder_path ? folder_path.length + 1 : 0)
                 .replace(/\.md$/, "");
 
             let folder: TFolder | undefined;

--- a/test/specs/create-new-note-from-template.e2e.ts
+++ b/test/specs/create-new-note-from-template.e2e.ts
@@ -66,6 +66,27 @@ describe("create_new_note_from_template", () => {
         );
     });
 
+    it("creates a file in the vault root without trimming its first character", async () => {
+        await resetVault("test/vault", {
+            "templates/template.md": "Root test",
+        });
+        const result = await browser.executeObsidian(async ({ app }) => {
+            const plugin = app.plugins.getPlugin("templater-obsidian");
+            if (!plugin) throw new Error("templater-obsidian is not loaded");
+            const handleCreateFromTemplate = Reflect.get(
+                plugin.command_handler,
+                "handle_create_from_template",
+            ) as (params: Record<string, string>) => Promise<string>;
+            return handleCreateFromTemplate.call(plugin.command_handler, {
+                template: "template",
+                file: "root-note.md",
+            });
+        });
+
+        expect(result).toBe("root-note.md");
+        await VaultPage.expectFileToHaveContent("root-note.md", "Root test");
+    });
+
     it("processes frontmatter and body", async () => {
         await resetVault("test/vault", {
             "templates/template.md":


### PR DESCRIPTION
## What changed

When `templater:create-from-template` creates a note in the vault root, `folder_path` is empty. The previous `slice(folder_path.length + 1)` call therefore removed the first character from the output file name. This keeps the existing subdirectory behavior while using the correct offset for root-level files.

A regression test now creates `root-note.md` in the vault root and verifies both the returned path and file content.

Closes #1763

## Testing

- `pnpm typecheck`
- `pnpm lint`
- `pnpm build` (successful; local plugin reload was skipped because the `obsidian` CLI is not installed)
- `pnpm exec wdio run ./wdio.conf.mts --spec test/specs/create-new-note-from-template.e2e.ts` (blocked before test execution: the Obsidian service could not download Obsidian because `fetch` failed)